### PR TITLE
Cross-window message hardening

### DIFF
--- a/packages/veritone-widgets-server/index.js
+++ b/packages/veritone-widgets-server/index.js
@@ -28,6 +28,7 @@ passport.use(new Strategy({
   return done(null, profile);
 }));
 const oauthError = (err, req, res, next) => {
+  console.log("Passport-Veritone OAuth2 Error", err);
   res.render('oauth_error', { clientOrigin: settings.clientOrigin });
   next();
 };

--- a/packages/veritone-widgets-server/index.js
+++ b/packages/veritone-widgets-server/index.js
@@ -27,15 +27,28 @@ passport.use(new Strategy({
 }, function(accessToken, refreshToken, profile, done) {
   return done(null, profile);
 }));
+const oauthError = (err, req, res, next) => {
+  res.render('oauth_error', { clientOrigin: settings.clientOrigin });
+  next();
+};
 
 app.get('/auth/veritone', passport.authenticate('veritone'));
 
-app.get('/auth/veritone/callback', passport.authenticate('veritone', { session: false }), (req, res) => {
-    if(!settings.clientOrigin) {
-        console.error("Must specifiy the client origin for safety");
+app.get(
+  '/auth/veritone/callback',
+  passport.authenticate('veritone', { session: false }),
+  (req, res) => {
+    if (!settings.clientOrigin) {
+      console.error('Must specifiy the client origin for safety');
     }
-    res.render('oauth', {oauthToken: req.user.oauthToken, clientOrigin: settings.clientOrigin});
-  });
+    res.render('oauth', {
+      oauthToken: req.user.oauthToken,
+      clientOrigin: settings.clientOrigin
+    });
+  }
+);
+
+app.use(oauthError);
 
 // start server
 // --------------------------------

--- a/packages/veritone-widgets-server/views/oauth_error.ejs
+++ b/packages/veritone-widgets-server/views/oauth_error.ejs
@@ -1,0 +1,17 @@
+<html>
+  <body>
+      <script>
+          var self = this;
+          window.onload = function() {
+              self.bindToContext = (event) => {
+                  if(event.origin === '<%= clientOrigin %>' || ( event.origin + '/' ) === '<%= clientOrigin %>') {
+                      self.origin = event.origin;
+                      self.source = event.source;
+                      event.source.postMessage({ error: 'oauth2_error' }, self.origin);
+                  }
+              }
+              window.addEventListener('message', self.bindToContext, false);
+          }
+      </script>
+  </body>
+</html>

--- a/packages/veritone-widgets/src/shared/VeritoneAuth.js
+++ b/packages/veritone-widgets/src/shared/VeritoneAuth.js
@@ -22,15 +22,16 @@ const removeAuthWindowListener = () => {
 };
 
 const createAuthWindowListener = (OAuthURI, resolve, reject) => {
+  removeAuthWindowListener();
   return function authWindowListener(event) {
     let uri = ParseURI(OAuthURI);
     if (event.origin === `${uri.origin}`) {
       let message = event.data;
       if (message && message.token) {
         _OAuthToken = message.token;
-        resolve({ OAuthToken: _OAuthToken });
         removeAuthWindowListener();
         cleanupAuthWindow();
+        resolve({ OAuthToken: _OAuthToken });
       }
     }
   };
@@ -42,7 +43,7 @@ const askOAuthServerForToken = (OAuthURI, resolve, reject) => {
     // keep polling until we receive a response
     if (!_OAuthToken) {
       if (_authWindow) {
-        _authWindow.postMessage('getOAuthToken', `${uri.origin}`);
+        _authWindow.postMessage('getOAuthToken', `*`);
       }
 
       // if the auth window is closed, stop polling
@@ -59,25 +60,26 @@ const askOAuthServerForToken = (OAuthURI, resolve, reject) => {
   }, _POLL_TIME);
 };
 
-const login = OAuthURI => {
+const login = async OAuthURI => {
   if (!OAuthURI) {
     throw new Error(
       'Missing parameter: Need to include the backend OAuth2 URI'
     );
   }
 
-  removeAuthWindowListener();
+  if (_OAuthToken) {
+    const loggedOut = await logout();
+  }
+
   _authWindow = window.open(OAuthURI, '_auth', 'width=550px,height=650px');
   return new Promise((resolve, reject) => {
-    window.addEventListener(
-      'message',
-      createAuthWindowListener(OAuthURI, resolve, reject)
-    );
+    _authWindowListener = createAuthWindowListener(OAuthURI, resolve, reject);
+    window.addEventListener('message', _authWindowListener);
     askOAuthServerForToken(OAuthURI, resolve, reject);
   });
 };
 
-const logout = () => {
+const logout = async () => {
   return new Promise((resolve, reject) => {
     removeAuthWindowListener();
     cleanupAuthWindow();

--- a/packages/veritone-widgets/src/shared/VeritoneAuth.js
+++ b/packages/veritone-widgets/src/shared/VeritoneAuth.js
@@ -27,11 +27,21 @@ const createAuthWindowListener = (OAuthURI, resolve, reject) => {
     let uri = ParseURI(OAuthURI);
     if (event.origin === `${uri.origin}`) {
       let message = event.data;
+      // reject the login promise if there's any oauth2 error from widget-server
+      if (message && message.error) {
+        removeAuthWindowListener();
+        cleanupAuthWindow();
+        reject(new Error('Veritone OAuth2 Error'));
+        return
+      }
+
+      // resolve the login promise if a token is present
       if (message && message.token) {
         _OAuthToken = message.token;
         removeAuthWindowListener();
         cleanupAuthWindow();
         resolve({ OAuthToken: _OAuthToken });
+        return
       }
     }
   };


### PR DESCRIPTION
- Moved the singleton to the factory to remove a possible race condition
- Relaxed the cross-origin message event on the “gotOAuthToken?” to avoid a cross-origin error.
- Force a logout when clicking logging in when already logged in to better cleanup the state.
- Save the `authWindowListener` to better enforce the singleton.