### PR TITLE
Addition of babel-runtime and babel-plugin-transform-runtime

### DIFF
--- a/packages/veritone-widgets/.babelrc
+++ b/packages/veritone-widgets/.babelrc
@@ -5,6 +5,7 @@
     "transform-decorators-legacy",
     "transform-class-properties",
     "transform-object-rest-spread",
+    "transform-runtime",
     "lodash"
   ]
 }

--- a/packages/veritone-widgets/package.json
+++ b/packages/veritone-widgets/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-polyfill": "^6.26.0",
+    "babel-runtime": "^6.26.0",
     "es6-promise": "^4.1.1",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
@@ -28,6 +29,7 @@
     "@storybook/addon-knobs": "3.3.0-alpha.4",
     "@storybook/react": "v3.3.0-alpha.4",
     "babel-plugin-lodash": "^3.3.2",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "cross-env": "^5.1.1",
     "enzyme": "^3.1.0",
     "enzyme-adapter-react-16": "^1.0.2",

--- a/packages/veritone-widgets/src/shared/VeritoneApp.js
+++ b/packages/veritone-widgets/src/shared/VeritoneApp.js
@@ -1,5 +1,3 @@
-import 'babel-polyfill'; // fixme
-
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { isFunction, isObject } from 'lodash';

--- a/packages/veritone-widgets/webpack.config.js
+++ b/packages/veritone-widgets/webpack.config.js
@@ -21,7 +21,10 @@ module.exports = {
       {
         test: /\.jsx?$/,
         include: path.resolve('./src'),
-        loader: 'babel-loader'
+        loader: 'babel-loader',
+        query: {
+          plugins: ['transform-runtime']
+        }
       },
       {
         test: /\.scss$/,

--- a/packages/veritone-widgets/webpack.config.js
+++ b/packages/veritone-widgets/webpack.config.js
@@ -21,10 +21,7 @@ module.exports = {
       {
         test: /\.jsx?$/,
         include: path.resolve('./src'),
-        loader: 'babel-loader',
-        query: {
-          plugins: ['transform-runtime']
-        }
+        loader: 'babel-loader'
       },
       {
         test: /\.scss$/,


### PR DESCRIPTION
babel-polyfill was causing an error when trying to use veritone-widgets in cms so I added babel-runtime and babel-plugin-transform-runtime and updated the webpack config to include the transform