### PR TITLE
Add Sentiment pill to search bar.

### DIFF
--- a/packages/veritone-react-common/src/components/SearchBar/story.js
+++ b/packages/veritone-react-common/src/components/SearchBar/story.js
@@ -9,6 +9,13 @@ import {
   TranscriptDisplay,
   TranscriptConditionGenerator
 } from 'components/TranscriptSearchModal';
+
+import {
+  SentimentSearchModal,
+  SentimentDisplay,
+  SentimentConditionGenerator
+} from 'components/SentimentSearchModal';
+
 import SearchBarContainer from './SearchBarContainer';
 import { SearchBar } from '.';
 
@@ -20,16 +27,30 @@ const transcript = {
   enablePill: true,
   showPill: true
 };
+const sentiment = {
+  id: 'searchbar-sentiment-id',
+  name: 'Sentiment',
+  iconClass: 'icon-sentiment',
+  tooltip: 'Search by Sentiment',
+  enablePill: true,
+  showPill: true
+};
+
 
 const appBarColor = '#4caf50';
 
-const enabledEngineCategories = [transcript];
+const enabledEngineCategories = [transcript, sentiment];
 
 const engineCategoryMapping = {
   '67cd4dd0-2f75-445d-a6f0-2f297d6cd182': {
     modal: TranscriptSearchModal,
     getLabel: TranscriptDisplay,
     generateCondition: TranscriptConditionGenerator
+  },
+  'searchbar-sentiment-id': {
+    modal: SentimentSearchModal,
+    getLabel: SentimentDisplay,
+    generateCondition: SentimentConditionGenerator
   }
 };
 

--- a/packages/veritone-react-common/src/components/SearchBar/styles.scss
+++ b/packages/veritone-react-common/src/components/SearchBar/styles.scss
@@ -18,6 +18,7 @@
   margin-right: 0.25em;
   margin-left: 0.25em;
   height: 38px;
+  display: flex;
 }
 
 .searchInput {

--- a/packages/veritone-react-common/src/components/SentimentSearchModal/index.js
+++ b/packages/veritone-react-common/src/components/SentimentSearchModal/index.js
@@ -1,0 +1,120 @@
+import React from 'react';
+import Button from 'material-ui/Button';
+import Select from 'material-ui/Select';
+import { MenuItem } from 'material-ui/Menu';
+import { FormHelperText } from 'material-ui/Form';
+
+import Dialog, {
+  DialogActions,
+  DialogContent,
+  DialogTitle
+} from 'material-ui/Dialog';
+
+import { bool, func, string, shape } from 'prop-types';
+
+export default class SentimentSearchModal extends React.Component {
+  static propTypes = {
+    open: bool,
+    modalState: shape({ search: string }),
+    applyFilter: func,
+    cancel: func
+  };
+  static defaultProps = {
+    applyFilter: value => console.log('Search sentiment', value),
+    cancel: () => console.log('You clicked cancel')
+  };
+
+  state = {
+    filterValue: null || this.props.modalState.search
+  };
+
+  onChange = event => {
+    this.setState({
+      filterValue: event.target.value
+    });
+  };
+
+  applyFilterIfValue = () => {
+    this.props.applyFilter(
+      { search: this.state.filterValue ? this.state.filterValue.trim() : null }
+    );
+  };
+
+  render() {
+    return (
+      <Dialog
+        open={this.props.open}
+        onRequestClose={this.props.cancel}
+        onEscapeKeyUp={this.props.cancel}
+      >
+        <SentimentSearchForm
+          cancel={ this.props.cancel }
+          onSubmit={ this.applyFilterIfValue }
+          onChange={ this.onChange }
+          inputValue={ this.state.filterValue }
+        />
+      </Dialog>
+    );
+  }
+}
+
+export const SentimentSearchForm = ( { cancel, onSubmit, onChange, inputValue } ) => {
+  return (
+    <div>
+      <DialogTitle>Search by Sentiment</DialogTitle>
+      <DialogContent style={{ width: '500px', margin: 'none' }}>
+        <Select
+          id="sentiment_search_field"
+          margin="none"
+          value={ inputValue }
+          onChange={ onChange }>
+          <MenuItem value={'Positive'}>Positive</MenuItem>
+          <MenuItem value={'Negative'}>Negative</MenuItem>
+        </Select>
+        <FormHelperText>Discover positive and negative sentiment inside of audio and video files.</FormHelperText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={ cancel } color="primary" className="sentimentSearchCancel">
+          Cancel
+        </Button>
+        <Button
+          onClick={ onSubmit }
+          color="primary"
+          className="sentimentSearchSubmit"
+          raised
+        >
+          Search
+        </Button>
+      </DialogActions>
+    </div>
+  )};
+
+SentimentSearchModal.defaultProps = {
+  modalState: { search: 'Positive' }
+};
+
+const SentimentConditionGenerator = modalState => {
+  const sentimentOperator = {
+    operator: "range",
+    field: "sentiment-veritone.series.score"
+  };
+  if (modalState.search == 'Positive') {
+    sentimentOperator.gte = "0.5";
+  } else {
+    sentimentOperator.lt = "0.5";
+  }
+  return sentimentOperator;
+};
+
+const SentimentDisplay = modalState => {
+  return {
+    abbreviation: modalState.search,
+    thumbnail: null
+  };
+};
+
+export {
+  SentimentSearchModal,
+  SentimentConditionGenerator,
+  SentimentDisplay
+};

--- a/packages/veritone-react-common/src/components/SentimentSearchModal/index.js
+++ b/packages/veritone-react-common/src/components/SentimentSearchModal/index.js
@@ -35,9 +35,13 @@ export default class SentimentSearchModal extends React.Component {
   };
 
   applyFilterIfValue = () => {
-    this.props.applyFilter(
-      { search: this.state.filterValue ? this.state.filterValue.trim() : null }
-    );
+    if(!this.state.filterValue || this.state.filterValue.trim().length === 0) {
+      this.props.applyFilter();
+    } else {
+      this.props.applyFilter(
+        { search: this.state.filterValue ? this.state.filterValue.trim() : null }
+      );
+    }
   };
 
   render() {

--- a/packages/veritone-react-common/src/components/SentimentSearchModal/index.test.js
+++ b/packages/veritone-react-common/src/components/SentimentSearchModal/index.test.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { SentimentSearchForm } from './';
+
+describe('SentimentSearchModal', () => {
+  it('Should render in initial state with value being set', () => {
+    const wrapper = mount(<SentimentSearchForm inputValue={ "Positive" } />);
+    expect(wrapper.find("input").instance().value).toEqual('Positive');
+  });
+
+  it('Should change state once new value has been selected', () => {
+    const wrapper = mount(<SentimentSearchForm inputValue={ "Negative" }/>);
+    expect(wrapper.find("input").instance().value).toEqual('Negative');
+    const wrapper2 = mount(<SentimentSearchForm inputValue={ "Positive" }/>);
+    expect(wrapper2.find("input").instance().value).toEqual('Positive');
+  });
+
+  it('Expect cancel button to call cancel function', () => {
+    const cancel = jest.fn();
+    let wrapper = mount(<SentimentSearchForm inputValue={ "Positive" } cancel={ cancel } />);
+    wrapper.find('button.sentimentSearchCancel').simulate('click');
+    expect(cancel).toHaveBeenCalled();
+  });
+
+  it('Except onSearch to be called when a value has been selected and the search button is pressed ', () => {
+    const submit = jest.fn();
+    let wrapper = mount(<SentimentSearchForm onSubmit={ submit } inputValue="Positive"/>);
+    wrapper.find('button.sentimentSearchSubmit').simulate('click');
+    expect(submit).toHaveBeenCalled();
+  });
+});

--- a/packages/veritone-react-common/src/components/SentimentSearchModal/story.js
+++ b/packages/veritone-react-common/src/components/SentimentSearchModal/story.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { SentimentSearchModal } from './';
+import { SentimentSearchForm } from './';
+
+import { boolean, object } from '@storybook/addon-knobs';
+
+storiesOf('SentimentSearchModal', module).add('withOpenDialog', () => {
+  const logFilter = value => console.log('filter value', value);
+  const cancel = () => console.log("cancel pressed");
+  return (
+    <SentimentSearchModal
+      open={boolean("Open", true)}
+      modalState={ object( "Search condition state", { "value": ('Positive') } ) }
+      cancel={ cancel }
+      applyFilter={logFilter}
+    />
+  );
+}).add( 'withoutDialog', () => {
+  return (
+    <SentimentSearchForm
+    />
+  );
+});


### PR DESCRIPTION
NOTE: according to core-search-server tests, V3 query for sentiment should have a clause: select: ['text-recognition', 'veritone-job', 'veritone-file'];
This is probably not a business of this component to add this clause, unless I'm missing smth.