### PR TITLE
VTN-6896:  remove redux-form-material-ui dependency

### DIFF
--- a/packages/veritone-react-common/package.json
+++ b/packages/veritone-react-common/package.json
@@ -21,8 +21,7 @@
     "react-infinite-calendar": "^2.3.1",
     "react-redux": "^5.0.6",
     "redux": "^3.7.2",
-    "redux-form": "^7.1.2",
-    "redux-form-material-ui": "^5.0.0-beta.2"
+    "redux-form": "^7.1.2"
   },
   "scripts": {
     "start": "NODE_ENV=test start-storybook -p 9001 -c .storybook",

--- a/packages/veritone-react-common/rollup.config.base.js
+++ b/packages/veritone-react-common/rollup.config.base.js
@@ -37,8 +37,7 @@ export default {
     'react-infinite-calendar',
     'react-redux',
     'redux',
-    'redux-form',
-    'redux-form-material-ui'
+    'redux-form'
   ],
   plugins: [
     replace({

--- a/packages/veritone-react-common/src/components/formComponents/RadioGroup.js
+++ b/packages/veritone-react-common/src/components/formComponents/RadioGroup.js
@@ -1,12 +1,15 @@
 import { RadioGroup } from 'material-ui/Radio';
 import { createComponent } from './redux-form-material-ui';
 
+import styles from './styles/radioGroup.scss';
+
 export default createComponent(
   RadioGroup,
   ({
     input: { onChange, value, ...inputProps },
     meta,
     onChange: onChangeFromField,
+    classes,
     ...props
   }) => ({
     ...inputProps,
@@ -17,6 +20,10 @@ export default createComponent(
       if (onChangeFromField) {
         onChangeFromField(value);
       }
+    },
+    classes: {
+      ...classes,
+      root: styles.container
     }
   })
 );

--- a/packages/veritone-react-common/src/components/formComponents/RadioGroup.js
+++ b/packages/veritone-react-common/src/components/formComponents/RadioGroup.js
@@ -1,15 +1,22 @@
-import React from 'react';
-import { RadioGroup as LibRadioGroup } from 'redux-form-material-ui';
+import { RadioGroup } from 'material-ui/Radio';
+import { createComponent } from './redux-form-material-ui';
 
-import styles from './styles/radioGroup.scss';
-
-const RadioGroup = props => (
-  <LibRadioGroup
-    classes={{
-      root: styles.container
-    }}
-    {...props}
-  />
+export default createComponent(
+  RadioGroup,
+  ({
+    input: { onChange, value, ...inputProps },
+    meta,
+    onChange: onChangeFromField,
+    ...props
+  }) => ({
+    ...inputProps,
+    ...props,
+    value,
+    onChange: (event, value) => {
+      onChange(value);
+      if (onChangeFromField) {
+        onChangeFromField(value);
+      }
+    }
+  })
 );
-
-export default RadioGroup;

--- a/packages/veritone-react-common/src/components/formComponents/Select.js
+++ b/packages/veritone-react-common/src/components/formComponents/Select.js
@@ -1,3 +1,23 @@
-import { Select } from 'redux-form-material-ui';
+import Select from 'material-ui/Select';
+import { createComponent, mapError } from './redux-form-material-ui';
 
-export default Select;
+export default createComponent(
+  Select,
+  ({
+    input: { onChange, value, onBlur, ...inputProps },
+    onChange: onChangeFromField,
+    defaultValue,
+    ...props
+  }) => ({
+    ...mapError(props),
+    ...inputProps,
+    value: value,
+    onChange: event => {
+      onChange(event.target.value);
+      if (onChangeFromField) {
+        onChangeFromField(event.target.value);
+      }
+    },
+    onBlur: () => onBlur(value)
+  })
+);

--- a/packages/veritone-react-common/src/components/formComponents/TextField.js
+++ b/packages/veritone-react-common/src/components/formComponents/TextField.js
@@ -1,3 +1,6 @@
-import { TextField } from 'redux-form-material-ui';
+import TextField from 'material-ui/TextField';
+import { createComponent, mapError } from './redux-form-material-ui';
 
-export default TextField;
+export default createComponent(TextField, ({ defaultValue, ...props }) => ({
+  ...mapError(props)
+}));

--- a/packages/veritone-react-common/src/components/formComponents/redux-form-material-ui.js
+++ b/packages/veritone-react-common/src/components/formComponents/redux-form-material-ui.js
@@ -1,0 +1,41 @@
+// this hopefully temporary file duplicates all the stuff in
+// https://github.com/erikras/redux-form-material-ui/blob/5.0/
+// because that library has dependency issues preventing it from working at the moment. We should be able to delete this file and just import from
+// that library, once the 5.0 branch is released.
+import { Component, createElement } from 'react';
+
+export const isStateLess = Component => !Component.prototype.render;
+
+export function createComponent(MaterialUIComponent, mapProps) {
+  class InputComponent extends Component {
+    getRenderedComponent() {
+      return this.component;
+    }
+
+    render() {
+      return createElement(MaterialUIComponent, {
+        ...mapProps(this.props),
+        ref: !isStateLess(MaterialUIComponent)
+          ? el => (this.component = el)
+          : null
+      });
+    }
+  }
+
+  InputComponent.displayName = `ReduxFormMaterialUI${MaterialUIComponent.name}`;
+  return InputComponent;
+}
+
+export const mapError = ({
+  meta: { touched, error, warning } = {},
+  input,
+  ...props
+}) =>
+  touched && (error || warning)
+    ? {
+        ...props,
+        ...input,
+        error: Boolean(error || warning),
+        helpertext: error || warning
+      }
+    : { ...input, ...props };

--- a/yarn.lock
+++ b/yarn.lock
@@ -10404,10 +10404,6 @@ redux-devtools@^3.4.0:
     prop-types "^15.5.7"
     redux-devtools-instrument "^1.0.1"
 
-redux-form-material-ui@^5.0.0-beta.2:
-  version "5.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/redux-form-material-ui/-/redux-form-material-ui-5.0.0-beta.2.tgz#4a9186d0a6216fbb5871b07156fb0e7f591fb3e8"
-
 redux-form@^7.1.2:
   version "7.2.1"
   resolved "https://registry.yarnpkg.com/redux-form/-/redux-form-7.2.1.tgz#011f6ff0cf050552a4a182a271f22217f4584684"


### PR DESCRIPTION
Redux-form-material-ui was causing build issues. I copied it into the SDK for now, so that we can hopefully go back to it seamlessly when the library is finally updated.

@charliemantle @gitrite 