### PR TITLE
GeoPicker component to be used in both modals + static pages.

### DIFF
--- a/packages/veritone-react-common/package.json
+++ b/packages/veritone-react-common/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "classnames": "^2.2.5",
     "date-fns": "^1.29.0",
+    "google-maps": "^3.3.0",
     "lodash": "^4.17.4",
     "material-ui": "v1.0.0-beta.36",
     "material-ui-icons": "^1.0.0-beta.17",

--- a/packages/veritone-react-common/src/components/GeoPicker/index.js
+++ b/packages/veritone-react-common/src/components/GeoPicker/index.js
@@ -1,0 +1,206 @@
+import React from 'react';
+import {
+  oneOf,
+  oneOfType,
+  shape,
+  func,
+  bool,
+  string,
+  number
+} from 'prop-types';
+
+import { CircularProgress } from 'material-ui/Progress';
+import Typography from 'material-ui/Typography';
+import GoogleMapsLoader from 'google-maps';
+
+import styles from './styles.scss';
+
+/* eslint-disable no-undef*/
+const MARKER = 'marker';
+const CIRCLE = 'circle';
+
+class GeoPicker extends React.Component {
+  static CIRCLE_OPTIONS = {
+    fillColor: '#aaaaaa',
+    fillOpacity: 0.35,
+    clickable: false,
+    editable: false,
+    strokeOpacity: 0.75,
+    strokeWeight: 2,
+    strokeColor: '#222222',
+    zIndex: 1
+  };
+
+  static GEOINPUT_OPTIONS = {
+    point: MARKER,
+    radius: CIRCLE
+  };
+  static UNIT_OF_DISTANCE = 'm';
+
+  googleMaps = null;
+  _googleMapsMountPoint = null;
+  _lastMarker = null;
+  _lastCircle = null;
+
+  loadedGoogleMaps = () => {
+    if (GeoPicker.GEOINPUT_OPTIONS[this.props.geoType] === MARKER) {
+      // single point
+      if (this.props.location) {
+        let position = {
+          lat: this.props.location.latitude,
+          lng: this.props.location.longitude
+        };
+
+        this._lastMarker = new google.maps.Marker({
+          position: position
+        });
+
+        this._lastMarker.setMap(this.googleMaps);
+        this.googleMaps.panTo(position);
+      }
+
+      if (!this.props.readOnly) {
+        google.maps.event.addListener(this.drawingManager, 'markercomplete', this.onDrawMarker);
+      }
+    } else if (
+      GeoPicker.GEOINPUT_OPTIONS[this.props.geoType] === CIRCLE
+    ) {
+      // radius based distance
+      if (this.props.location) {
+        this._lastCircle = new google.maps.Circle({
+          ...GeoPicker.CIRCLE_OPTIONS,
+          center: {
+            lat: this.props.location.latitude,
+            lng: this.props.location.longitude
+          },
+          radius: this.props.location.distance,
+          map: this.googleMaps
+        });
+
+        this.googleMaps.fitBounds(this._lastCircle.getBounds());
+      }
+
+      if (!this.props.readOnly) {
+        google.maps.event.addListener(this.drawingManager, 'circlecomplete', this.onDrawCircle);
+      }
+    }
+  };
+
+  mountGoogleMaps = () => {
+    const MAP_OPTIONS = {
+      zoom: 14,
+      center: { lng: -117.92, lat: 33.62 }
+    };
+
+    this.googleMaps = new google.maps.Map(
+      this._googleMapsMountPoint,
+      MAP_OPTIONS
+    );
+
+    if (!this.props.readOnly) {
+      this.drawingManager = new google.maps.drawing.DrawingManager({
+        drawingMode: GeoPicker.GEOINPUT_OPTIONS[this.props.geoType],
+        drawingControl: true,
+        drawingControlOptions: {
+          position: google.maps.ControlPosition.BOTTOM_CENTER,
+          drawingModes: [GeoPicker.GEOINPUT_OPTIONS[this.props.geoType]]
+        },
+        circleOptions: GeoPicker.CIRCLE_OPTIONS
+      });
+
+      this.drawingManager.setMap(this.googleMaps);
+    }
+
+    google.maps.event.addDomListener(
+      window,
+      'load',
+      this.loadedGoogleMaps
+    );
+  };
+
+  clearDraw = () => {
+    if (this._lastCircle) {
+      this._lastCircle.setMap(null);
+      this._lastCircle = null;
+    }
+
+    if (this._lastMarker) {
+      this._lastMarker.setMap(null);
+      this._lastMarker = null;
+    }
+  };
+
+  onDrawCircle = event => {
+    this.clearDraw();
+    this._lastCircle = event;
+
+    this.googleMaps.fitBounds(event.getBounds());
+
+    if (this.props.onSelectGeolocation) {
+      this.props.onSelectGeolocation({
+        distance: event.radius,
+        latitude: event.center.lat(),
+        longitude: event.center.lng(),
+        units: GeoPicker.UNIT_OF_DISTANCE
+      });
+    }
+  };
+
+  onDrawMarker = event => {
+    this.clearDraw();
+    this._lastMarker = event;
+
+    if (this.props.onSelectGeolocation) {
+      this.props.onSelectGeolocation({
+        latitude: event.position.lat(),
+        longitude: event.position.lng()
+      });
+    }
+  };
+
+  loadGoogleMaps = ref => {
+    this._googleMapsMountPoint = ref;
+    GoogleMapsLoader.KEY = this.props.gmapsAPIKey;
+    GoogleMapsLoader.LIBRARIES = ['places', 'drawing'];
+    GoogleMapsLoader.load(this.mountGoogleMaps);
+  };
+
+  render() {
+    return (
+      <div ref={this.loadGoogleMaps} style={ {width: "100%", height: "100%", display: 'flex' } }>
+        <div className={styles.loading_container}>
+          <CircularProgress
+            className={styles.loading_spinner}
+            size={100}
+            thickness={1}
+          />
+          <Typography className={styles.loading_label}>
+            Loading Google Maps
+          </Typography>
+        </div>
+      </div>
+    );
+  }
+}
+/* eslint-enable no-undef*/
+
+GeoPicker.propTypes = {
+  gmapsAPIKey: string.isRequired,
+  geoType: oneOf(['point', 'radius']).isRequired,
+  location: oneOfType([
+    shape({
+      distance: number,
+      latitude: number,
+      longitude: number,
+      units: oneOf([GeoPicker.UNIT_OF_DISTANCE])
+    }),
+    shape({
+      latitude: number,
+      longitude: number
+    })
+  ]),
+  readOnly: bool,
+  onSelectGeolocation: func
+};
+
+export default GeoPicker;

--- a/packages/veritone-react-common/src/components/GeoPicker/index.js
+++ b/packages/veritone-react-common/src/components/GeoPicker/index.js
@@ -64,6 +64,10 @@ class GeoPicker extends React.Component {
     defaultLongitude: -117.92
   };
 
+  componentWillUnmount() {
+    GoogleMapsLoader.release();
+  }
+
   googleMaps = null;
   _googleMapsMountPoint = null;
   _lastMarker = null;
@@ -71,6 +75,11 @@ class GeoPicker extends React.Component {
   drawingManager = null;
 
   mountGoogleMaps = google => {
+    // don't mount if it's already been unmounted
+    if (!this._googleMapsMountPoint) {
+      return;
+    }
+
     const MAP_OPTIONS = {
       zoom: this.props.defaultZoom,
       center: {

--- a/packages/veritone-react-common/src/components/GeoPicker/index.test.js
+++ b/packages/veritone-react-common/src/components/GeoPicker/index.test.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import GeoPicker from './';
+
+describe('GeoPicker', () => {
+
+  const gmapsAPIKey = 'AIzaSyDQyglufOtb_uzebFNkVWcB1D8-tBKZarQ';
+
+  let logLocation = jest.fn();
+  let geoPickerComponent = mount(
+    <GeoPicker
+    geoType="point"
+    onSelectGeolocation={logLocation}
+    location={{
+      latitude: 33.6118,
+      longitude: -117.9144
+    }}
+    gmapsAPIKey={gmapsAPIKey}
+  />
+  );
+
+  it('should render something', () => {
+    expect(geoPickerComponent.children()).toHaveLength(1);
+  });
+});

--- a/packages/veritone-react-common/src/components/GeoPicker/story.js
+++ b/packages/veritone-react-common/src/components/GeoPicker/story.js
@@ -1,0 +1,102 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { text } from '@storybook/addon-knobs/react';
+
+import GeoPicker from './';
+
+const logLocation = data => console.log('Geolocation', data);
+const gmapsAPIKey = 'AIzaSyDQyglufOtb_uzebFNkVWcB1D8-tBKZarQ';
+
+storiesOf('GeoPicker', module).add('Select a radius based distance', () => {
+  return (
+    <div style={{ width: '900px', height: '500px'}}>
+      <GeoPicker
+        geoType="radius"
+        onSelectGeolocation={logLocation}
+        gmapsAPIKey={text('gmapsAPIKey', gmapsAPIKey)}
+      />
+    </div>
+  );
+});
+
+storiesOf('GeoPicker', module).add('Select a single point ', () => {
+  return (
+    <div style={{ width: '900px', height: '500px'}}>
+      <GeoPicker
+        geoType="point"
+        onSelectGeolocation={logLocation}
+        gmapsAPIKey={text('gmapsAPIKey', gmapsAPIKey)}
+      />
+    </div>
+  );
+});
+
+storiesOf('GeoPicker', module).add('Deserialize a single point ', () => {
+  return (
+    <div style={{ width: '900px', height: '500px'}}>
+      <GeoPicker
+        geoType="point"
+        onSelectGeolocation={logLocation}
+        location={{
+          latitude: 33.6118,
+          longitude: -117.9144
+        }}
+        gmapsAPIKey={text('gmapsAPIKey', gmapsAPIKey)}
+      />
+    </div>
+  );
+});
+
+storiesOf('GeoPicker', module).add('Deserialize a radius ', () => {
+  return (
+    <div style={{ width: '900px', height: '500px'}}>
+      <GeoPicker
+        geoType="radius"
+        onSelectGeolocation={logLocation}
+        location={{
+          latitude: 33.6118,
+          longitude: -117.9144,
+          distance: 1000,
+          units: 'm'
+        }}
+        gmapsAPIKey={text('gmapsAPIKey', gmapsAPIKey)}
+      />
+    </div>
+  );
+});
+
+storiesOf('GeoPicker', module).add('Display a read-only radius', () => {
+  return (
+    <div style={{ width: '900px', height: '500px'}}>
+      <GeoPicker
+        geoType="radius"
+        location={{
+          latitude: 33.6118,
+          longitude: -117.9144,
+          distance: 1000,
+          units: 'm'
+        }}
+        readOnly
+        gmapsAPIKey={text('gmapsAPIKey', gmapsAPIKey)}
+      />
+    </div>
+  );
+});
+
+
+storiesOf('GeoPicker', module).add('Display a read-only point', () => {
+  return (
+    <div style={{ width: '900px', height: '500px'}}>
+      <GeoPicker
+        geoType="point"
+        location={{
+          latitude: 33.6118,
+          longitude: -117.9144,
+        }}
+        readOnly
+        gmapsAPIKey={text('gmapsAPIKey', gmapsAPIKey)}
+      />
+    </div>
+  );
+});
+

--- a/packages/veritone-react-common/src/components/GeoPicker/styles.scss
+++ b/packages/veritone-react-common/src/components/GeoPicker/styles.scss
@@ -1,0 +1,19 @@
+
+.loading_container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+}
+
+.loading_spinner {
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: 1em;
+}
+
+.loading_label {
+  width: 100%;
+  text-align: center;
+}

--- a/packages/veritone-react-common/src/index.js
+++ b/packages/veritone-react-common/src/index.js
@@ -26,3 +26,4 @@ export OAuthLoginButton from './components/OAuthLoginButton';
 export { Table, PaginatedTable, Column, LOADING } from './components/DataTable';
 export MenuColumn from './components/DataTable/MenuColumn';
 export SearchPill from './components/SearchPill';
+export GeoPicker from './components/GeoPicker';

--- a/yarn.lock
+++ b/yarn.lock
@@ -5204,6 +5204,10 @@ gonzales-pe@^4.0.3:
   dependencies:
     minimist "1.1.x"
 
+google-maps@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/google-maps/-/google-maps-3.3.0.tgz#4432b4715406bc15268ad35b1dd1b04d974956a6"
+
 got@^6.7.1:
   version "6.7.1"
   resolved "https://registry.yarnpkg.com/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0"


### PR DESCRIPTION
- Supports display a radius based distance, as well as a single geopoint. This will be used in contextMenus for the geopoint type, as well as the `Search by Geolocation` modal.

Ended up not using any of the React bindings because none of them are very good, they're kind of awkward since they end up storing a duplicate of Google map's internal state, meaning they have to write bindings for everything (some of which are missing and we need, see https://github.com/fullstackreact/google-maps-react/issues/171) 

Used https://github.com/Carrooi/Js-GoogleMapsLoader which is just an async loader.

Not sure if we need/how to test this either, since there's almost no React in this, all it is a declarative binding around Google Maps rendering a single marker or circle, and firing the callback when a marker or circle is created.