### PR TITLE
add DelayedProgress component

### DIFF
--- a/packages/veritone-react-common/src/components/DelayedProgress/index.js
+++ b/packages/veritone-react-common/src/components/DelayedProgress/index.js
@@ -1,0 +1,34 @@
+// https://material-ui.com/demos/progress/#delaying-appearance
+// when props.loading is set to true, will delay for props.delay ms before
+// showing a loading indicator.
+
+import React from 'react';
+import { number, bool, objectOf, any } from 'prop-types';
+import Fade from '@material-ui/core/Fade';
+import CircularProgress from '@material-ui/core/CircularProgress';
+
+export default class DelayedProgress extends React.Component {
+  static propTypes = {
+    loading: bool,
+    delay: number,
+    circularProgressProps: objectOf(any)
+  };
+  static defaultProps = {
+    delay: 800,
+    loading: false
+  };
+
+  render() {
+    return (
+      <Fade
+        in={this.props.loading}
+        style={{
+          transitionDelay: this.props.loading ? `${this.props.delay}ms` : '0ms'
+        }}
+        unmountOnExit
+      >
+        <CircularProgress {...this.props.circularProgressProps} />
+      </Fade>
+    );
+  }
+}

--- a/packages/veritone-react-common/src/components/DelayedProgress/index.test.js
+++ b/packages/veritone-react-common/src/components/DelayedProgress/index.test.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { createMount } from '@material-ui/core/test-utils';
+import CircularProgress from '@material-ui/core/CircularProgress';
+
+import DelayedProgress from './';
+
+let mount;
+beforeAll(() => {
+  mount = createMount();
+});
+
+describe('DelayedProgress', function() {
+  it('exists', function() {
+    const wrapper = mount(<DelayedProgress />);
+    expect(wrapper).toHaveLength(1);
+  });
+
+  it('has a CircularProgress element if props.loading is true', function() {
+    const wrapper = mount(<DelayedProgress />);
+    expect(wrapper.find(CircularProgress)).toHaveLength(0);
+
+    wrapper.setProps({ loading: true });
+    expect(wrapper.find(CircularProgress)).toHaveLength(1);
+  });
+
+  it('passes props.circularProgressProps to the CircularProgress component', function() {
+    const wrapper = mount(
+      <DelayedProgress loading circularProgressProps={{ size: 120 }} />
+    );
+    expect(wrapper.find(CircularProgress).prop('size')).toBe(120);
+  });
+});

--- a/packages/veritone-react-common/src/components/DelayedProgress/story.js
+++ b/packages/veritone-react-common/src/components/DelayedProgress/story.js
@@ -1,0 +1,60 @@
+import React, { Fragment } from 'react';
+import { number } from 'prop-types';
+import { storiesOf } from '@storybook/react';
+import { number as numberKnob } from '@storybook/addon-knobs';
+import Button from '@material-ui/core/Button';
+
+import DelayedProgress from './';
+
+class Story extends React.Component {
+  static propTypes = {
+    delay: number
+  };
+
+  state = {
+    loading: false
+  };
+
+  timer = null; // eslint-disable-line
+
+  componentWillUnmount() {
+    clearTimeout(this.timer);
+  }
+
+  handleLoad = () => {
+    this.setState({ loading: true });
+
+    this.timer = setTimeout(() => {
+      this.setState({
+        loading: false
+      });
+    }, 3000);
+  };
+
+  render() {
+    return (
+      <Fragment>
+        <p>Delay before indicator appears: {this.props.delay}ms</p>
+        <Button onClick={this.handleLoad}>Simulate a 3-second load</Button>
+        <div>
+          <DelayedProgress
+            delay={this.props.delay}
+            loading={this.state.loading}
+            circularProgressProps={{
+              size: 50
+            }}
+          />
+        </div>
+      </Fragment>
+    );
+  }
+}
+
+storiesOf('DelayedProgress', module).add('Base', () => {
+  const delay = numberKnob(
+    'delay before showing',
+    DelayedProgress.defaultProps.delay
+  );
+
+  return <Story delay={delay} />;
+});

--- a/packages/veritone-react-common/src/index.js
+++ b/packages/veritone-react-common/src/index.js
@@ -8,6 +8,7 @@ export AppFooter, {
 export AppSwitcher from './components/AppSwitcher';
 export Avatar from './components/Avatar';
 export Chip from './components/Chip';
+export DelayedProgress from './components/DelayedProgress';
 export NavigationSideBar, {
   sectionsShape as navigationSidebarSectionsShape
 } from './components/NavigationSideBar';


### PR DESCRIPTION
This wraps mui's CircularProgress with some logic to only appear after a certain delay, which is better from a UX perspective than immediately showing indicators for very short load times.