### PR TITLE
Sdo integration transcript/face save dialogs

### DIFF
--- a/packages/veritone-react-common/src/components/FaceEngineOutput/EntityInformation/index.js
+++ b/packages/veritone-react-common/src/components/FaceEngineOutput/EntityInformation/index.js
@@ -122,7 +122,8 @@ class EntityInformation extends Component {
           {this.state.activeTab === 'metadata' && (
             <div className={styles.tabContainer}>
               <div className={styles.entityJson}>
-                {!!Object.keys(entity.jsondata).length &&
+                {entity.jsondata &&
+                  !!Object.keys(entity.jsondata).length &&
                   Object.keys(entity.jsondata).map((objKey, index) => {
                     return (
                       <div

--- a/packages/veritone-react-common/src/components/FingerprintEngineOutput/FingerprintEntity/EntityMetadata/index.js
+++ b/packages/veritone-react-common/src/components/FingerprintEngineOutput/FingerprintEntity/EntityMetadata/index.js
@@ -15,18 +15,19 @@ export default class EntityMetadata extends Component {
 
     return (
       <div className={classNames(styles.fingerprintEntityMetadata, className)}>
-        {Object.keys(jsondata).map(propName => {
-          const propVal = jsondata[propName];
-          return (
-            <div
-              className={classNames(styles.entry)}
-              key={`metadata-${propName}-${propVal}`}
-            >
-              <div className={classNames(styles.label)}>{propName}</div>
-              <div>{propVal}</div>
-            </div>
-          );
-        })}
+        {jsondata && 
+          Object.keys(jsondata).map(propName => {
+            const propVal = jsondata[propName];
+            return (
+              <div
+                className={classNames(styles.entry)}
+                key={`metadata-${propName}-${propVal}`}
+              >
+                <div className={classNames(styles.label)}>{propName}</div>
+                <div>{propVal}</div>
+              </div>
+            );
+          })}
       </div>
     );
   }

--- a/packages/veritone-widgets/src/redux/modules/mediaDetails/faceEngineOutput/index.js
+++ b/packages/veritone-widgets/src/redux/modules/mediaDetails/faceEngineOutput/index.js
@@ -92,10 +92,7 @@ const reducer = createReducer(defaultState, {
     const resultsGroupedByEngineId = groupBy(engineResults, 'engineId');
 
     forEach(resultsGroupedByEngineId, (results, engineId) => {
-      if (!previousResultsByEngineId[engineId]) {
-        // Data hasn't been retrieved for this engineId yet
-        previousResultsByEngineId[engineId] = map(results, 'jsondata');
-      }
+      previousResultsByEngineId[engineId] = map(results, 'jsondata');
     });
 
     return {

--- a/packages/veritone-widgets/src/redux/modules/mediaDetails/faceEngineOutput/index.js
+++ b/packages/veritone-widgets/src/redux/modules/mediaDetails/faceEngineOutput/index.js
@@ -5,6 +5,7 @@ export const FETCHING_ENGINE_RESULTS = `vtn/${namespace}/FETCHING_ENGINE_RESULTS
 export const FETCH_ENGINE_RESULTS_SUCCESS = `vtn/${namespace}/FETCH_ENGINE_RESULTS_SUCCESS`;
 export const FETCH_ENGINE_RESULTS_FAILURE = `vtn/${namespace}/FETCH_ENGINE_RESULTS_FAILURE`;
 export const DONE_FETCHING_ENGINE_RESULTS = `vtn/${namespace}/DONE_FETCHING_ENGINE_RESULTS`;
+export const CLEAR_FACE_ENGINE_RESULTS_BY_ENGINE_ID = `vtn/${namespace}/CLEAR_FACE_ENGINE_RESULTS_BY_ENGINE_ID`;
 
 export const FETCH_ENTITIES = `vtn/${namespace}/FETCH_ENTITIES`;
 export const FETCH_ENTITIES_SUCCESS = `vtn/${namespace}/FETCH_ENTITIES_SUCCESS`;
@@ -106,6 +107,35 @@ const reducer = createReducer(defaultState, {
   [FETCH_ENGINE_RESULTS_FAILURE](state, { payload, meta }) {
     return {
       ...state
+    };
+  },
+  [CLEAR_FACE_ENGINE_RESULTS_BY_ENGINE_ID](state, { payload }) {
+    function removeEngineId(myObj, deleteEngineId) {
+      return Object.keys(myObj)
+        .filter(key => key !== deleteEngineId)
+        .reduce((result, current) => {
+          result[current] = myObj[current];
+          return result;
+        }, {});
+    }
+    return {
+      ...state,
+      engineResultsByEngineId: removeEngineId(
+        state.engineResultsByEngineId,
+        payload.engineId
+      ),
+      fetchedEngineResults: removeEngineId(
+        state.fetchedEngineResults,
+        payload.engineId
+      ),
+      facesDetectedByUser: removeEngineId(
+        state.facesDetectedByUser,
+        payload.engineId
+      ),
+      facesRemovedByUser: removeEngineId(
+        state.facesRemovedByUser,
+        payload.engineId
+      )
     };
   },
   [FETCH_ENTITIES](state, action) {
@@ -324,6 +354,10 @@ export const fetchEngineResultsFailure = (error, meta) => ({
   error,
   meta
 });
+export const clearFaceEngineResultsByEngineId = engineId => ({
+  type: CLEAR_FACE_ENGINE_RESULTS_BY_ENGINE_ID,
+  payload: { engineId }
+});
 
 export function isFetchingEngineResults(state) {
   return local(state).isFetchingEngineResults;
@@ -507,7 +541,7 @@ export const getFaceEngineAssetData = (state, engineId) => {
   // On the result use engineAliasId for 'user-edited-face-engine-results'
   const userEdited = {
     sourceEngineId: '7a3d86bf-331d-47e7-b55c-0434ec6fe5fd',
-    sourceEngineName: 'User Generated'
+    sourceEngineName: 'User Edited'
   };
 
   const allSeries = addUserDetectedFaces(

--- a/packages/veritone-widgets/src/redux/modules/mediaDetails/faceEngineOutput/index.js
+++ b/packages/veritone-widgets/src/redux/modules/mediaDetails/faceEngineOutput/index.js
@@ -28,6 +28,9 @@ export const ADD_DETECTED_FACE = `vtn/${namespace}/ADD_DETECTED_FACE`;
 export const REMOVE_DETECTED_FACE = `vtn/${namespace}/REMOVE_DETECTED_FACE`;
 export const CANCEL_FACE_EDITS = `vtn/${namespace}/CANCEL_FACE_EDITS`;
 
+export const OPEN_CONFIRMATION_DIALOG = `vtn/${namespace}/OPEN_CONFIRMATION_DIALOG`;
+export const CLOSE_CONFIRMATION_DIALOG = `vtn/${namespace}/CLOSE_CONFIMATION_DIALOG`;
+
 import {
   get,
   map,
@@ -40,7 +43,8 @@ import {
   set,
   pick,
   flatten,
-  pullAt
+  pullAt,
+  noop
 } from 'lodash';
 import { helpers } from 'veritone-redux-common';
 import { createSelector } from 'reselect';
@@ -58,7 +62,9 @@ const defaultState = {
   isFetchingLibraries: false,
   isSearchingEntities: false,
   facesDetectedByUser: {},
-  facesRemovedByUser: {}
+  facesRemovedByUser: {},
+  showConfirmationDialog: false,
+  confirmationAction: noop
 };
 
 const reducer = createReducer(defaultState, {
@@ -324,6 +330,21 @@ const reducer = createReducer(defaultState, {
       facesDetectedByUser: {},
       facesRemovedByUser: {}
     };
+  },
+  [OPEN_CONFIRMATION_DIALOG](state, action) {
+    const { confirmationAction } = action.payload;
+    return {
+      ...state,
+      showConfirmationDialog: true,
+      confirmationAction: confirmationAction || noop
+    };
+  },
+  [CLOSE_CONFIRMATION_DIALOG](state, action) {
+    return {
+      ...state,
+      showConfirmationDialog: false,
+      confirmationAction: noop
+    };
   }
 });
 export default reducer;
@@ -370,6 +391,10 @@ export const getUserDetectedFaces = (state, engineId) =>
 
 export const getUserRemovedFaces = (state, engineId) =>
   get(local(state), ['facesRemovedByUser', engineId]);
+
+export const pendingUserEdits = (state, engineId) =>
+  !isEmpty(getUserDetectedFaces(state, engineId)) ||
+  !isEmpty(getUserRemovedFaces(state, engineId));
 
 export const fetchedEngineResultByEngineId = (state, engineId) =>
   get(local(state), ['fetchedEngineResults', engineId], []);
@@ -486,6 +511,26 @@ export const removeDetectedFace = (selectedEngineId, faceObj) => ({
 export const cancelFaceEdits = () => ({
   type: CANCEL_FACE_EDITS
 });
+
+/* CONFIRMATION DIALOG */
+export const openConfirmationDialog = confirmationAction => {
+  return {
+    type: OPEN_CONFIRMATION_DIALOG,
+    payload: {
+      confirmationAction
+    }
+  };
+};
+
+export const closeConfirmationDialog = () => ({
+  type: CLOSE_CONFIRMATION_DIALOG
+});
+
+export const showConfirmationDialog = state =>
+  get(local(state), 'showConfirmationDialog');
+
+export const confirmationAction = state =>
+  get(local(state), 'confirmationAction');
 
 /* SELECTORS */
 export const getFaces = createSelector(

--- a/packages/veritone-widgets/src/redux/modules/mediaDetails/faceEngineOutput/index.js
+++ b/packages/veritone-widgets/src/redux/modules/mediaDetails/faceEngineOutput/index.js
@@ -5,7 +5,6 @@ export const FETCHING_ENGINE_RESULTS = `vtn/${namespace}/FETCHING_ENGINE_RESULTS
 export const FETCH_ENGINE_RESULTS_SUCCESS = `vtn/${namespace}/FETCH_ENGINE_RESULTS_SUCCESS`;
 export const FETCH_ENGINE_RESULTS_FAILURE = `vtn/${namespace}/FETCH_ENGINE_RESULTS_FAILURE`;
 export const DONE_FETCHING_ENGINE_RESULTS = `vtn/${namespace}/DONE_FETCHING_ENGINE_RESULTS`;
-export const CLEAR_FACE_ENGINE_RESULTS_BY_ENGINE_ID = `vtn/${namespace}/CLEAR_FACE_ENGINE_RESULTS_BY_ENGINE_ID`;
 
 export const FETCH_ENTITIES = `vtn/${namespace}/FETCH_ENTITIES`;
 export const FETCH_ENTITIES_SUCCESS = `vtn/${namespace}/FETCH_ENTITIES_SUCCESS`;
@@ -110,35 +109,6 @@ const reducer = createReducer(defaultState, {
   [FETCH_ENGINE_RESULTS_FAILURE](state, { payload, meta }) {
     return {
       ...state
-    };
-  },
-  [CLEAR_FACE_ENGINE_RESULTS_BY_ENGINE_ID](state, { payload }) {
-    function removeEngineId(myObj, deleteEngineId) {
-      return Object.keys(myObj)
-        .filter(key => key !== deleteEngineId)
-        .reduce((result, current) => {
-          result[current] = myObj[current];
-          return result;
-        }, {});
-    }
-    return {
-      ...state,
-      engineResultsByEngineId: removeEngineId(
-        state.engineResultsByEngineId,
-        payload.engineId
-      ),
-      fetchedEngineResults: removeEngineId(
-        state.fetchedEngineResults,
-        payload.engineId
-      ),
-      facesDetectedByUser: removeEngineId(
-        state.facesDetectedByUser,
-        payload.engineId
-      ),
-      facesRemovedByUser: removeEngineId(
-        state.facesRemovedByUser,
-        payload.engineId
-      )
     };
   },
   [FETCH_ENTITIES](state, action) {
@@ -371,10 +341,6 @@ export const fetchEngineResultsFailure = (error, meta) => ({
   type: FETCH_ENGINE_RESULTS_FAILURE,
   error,
   meta
-});
-export const clearFaceEngineResultsByEngineId = engineId => ({
-  type: CLEAR_FACE_ENGINE_RESULTS_BY_ENGINE_ID,
-  payload: { engineId }
 });
 
 export function isFetchingEngineResults(state) {

--- a/packages/veritone-widgets/src/redux/modules/mediaDetails/index.js
+++ b/packages/veritone-widgets/src/redux/modules/mediaDetails/index.js
@@ -9,7 +9,8 @@ import {
   values,
   uniqBy,
   keyBy,
-  isMatch
+  isMatch,
+  noop
 } from 'lodash';
 import { helpers } from 'veritone-redux-common';
 const { createReducer } = helpers;
@@ -63,6 +64,9 @@ export const CREATE_BULK_EDIT_TRANSCRIPT_ASSET_SUCCESS =
 export const CREATE_BULK_EDIT_TRANSCRIPT_ASSET_FAILURE =
   'CREATE_BULK_EDIT_TRANSCRIPT_ASSET_FAILURE';
 export const REFRESH_ENGINE_RUNS_SUCCESS = 'REFRESH_ENGINE_RUNS_SUCCESS';
+export const SHOW_CONFIRM_DIALOG = 'SHOW_CONFIRM_DIALOG';
+export const CLOSE_CONFIRM_DIALOG = 'CLOSE_CONFIRM_DIALOG';
+export const DISCARD_UNSAVED_CHANGES = 'DISCARD_UNSAVED_CHANGES';
 
 export const namespace = 'mediaDetails';
 
@@ -84,7 +88,15 @@ const defaultMDPState = {
   tdoContentTemplates: {},
   schemasById: {},
   enableSave: false,
-  error: null
+  error: null,
+  alertDialogConfig: {
+    show: false,
+    title: 'Save Changes?',
+    description: 'Would you like to save the changes?',
+    cancelButtonLabel: 'Discard',
+    confirmButtonLabel: 'Save',
+    nextAction: noop
+  }
 };
 
 const defaultState = {};
@@ -792,6 +804,40 @@ export default createReducer(defaultState, {
         }
       }
     };
+  },
+  [SHOW_CONFIRM_DIALOG](
+    state,
+    {
+      payload,
+      meta: { widgetId }
+    }
+  ) {
+    return {
+      ...state,
+      [widgetId]: {
+        ...state[widgetId],
+        alertDialogConfig: {
+          ...state[widgetId].alertDialogConfig,
+          ...payload
+        }
+      }
+    };
+  },
+  [CLOSE_CONFIRM_DIALOG](
+    state,
+    {
+      meta: { widgetId }
+    }
+  ) {
+    return {
+      ...state,
+      [widgetId]: {
+        ...state[widgetId],
+        alertDialogConfig: {
+          ...defaultMDPState.alertDialogConfig
+        }
+      }
+    };
   }
 });
 
@@ -850,6 +896,8 @@ export const isUserGeneratedEngineId = engineId => {
     isUserGeneratedFaceEngineId(engineId)
   );
 };
+export const getAlertDialogConfig = (state, widgetId) =>
+  get(local(state), [widgetId, 'alertDialogConfig']);
 
 export const initializeWidget = widgetId => ({
   type: INITIALIZE_WIDGET,
@@ -1054,4 +1102,21 @@ export const refreshEngineRunsSuccess = (engineRuns, widgetId) => ({
     engineRuns
   },
   meta: { widgetId }
+});
+export const openConfirmModal = (nextAction, widgetId) => ({
+  type: SHOW_CONFIRM_DIALOG,
+  payload: {
+    show: true,
+    nextAction: nextAction
+  },
+  meta: { widgetId }
+});
+
+export const closeConfirmModal = widgetId => ({
+  type: CLOSE_CONFIRM_DIALOG,
+  meta: { widgetId }
+});
+
+export const discardUnsavedChanges = () => ({
+  type: DISCARD_UNSAVED_CHANGES
 });

--- a/packages/veritone-widgets/src/redux/modules/mediaDetails/saga.js
+++ b/packages/veritone-widgets/src/redux/modules/mediaDetails/saga.js
@@ -68,6 +68,7 @@ import {
   isEditModeEnabled,
   isUserGeneratedTranscriptEngineId,
   isUserGeneratedFaceEngineId,
+  toggleEditMode,
   getSelectedEngineCategory,
   refreshEngineRunsSuccess,
   clearEngineResultsByEngineId,
@@ -762,6 +763,7 @@ function* createFileAssetSaga(
       yield put({ type: TRANSCRIPT_RESET });
       yield put(clearEngineResultsByEngineId(userGeneratedEngineId, widgetId));
     }
+    yield put(toggleEditMode(widgetId, selectedEngineCategory));
     yield put(selectEngineCategory(widgetId, updatedCategory));
     yield put(createFileAssetSuccess(widgetId, assetId));
   }

--- a/packages/veritone-widgets/src/redux/modules/mediaDetails/saga.js
+++ b/packages/veritone-widgets/src/redux/modules/mediaDetails/saga.js
@@ -68,7 +68,6 @@ import {
   isEditModeEnabled,
   isUserGeneratedTranscriptEngineId,
   isUserGeneratedFaceEngineId,
-  toggleEditMode,
   getSelectedEngineCategory,
   refreshEngineRunsSuccess,
   clearEngineResultsByEngineId,
@@ -763,7 +762,6 @@ function* createFileAssetSaga(
       yield put({ type: TRANSCRIPT_RESET });
       yield put(clearEngineResultsByEngineId(userGeneratedEngineId, widgetId));
     }
-    yield put(toggleEditMode(widgetId, selectedEngineCategory));
     yield put(selectEngineCategory(widgetId, updatedCategory));
     yield put(createFileAssetSuccess(widgetId, assetId));
   }

--- a/packages/veritone-widgets/src/redux/modules/mediaDetails/saga.js
+++ b/packages/veritone-widgets/src/redux/modules/mediaDetails/saga.js
@@ -1419,7 +1419,7 @@ function* watchSelectEngineCategory() {
 
 function* watchTranscriptStatus() {
   yield takeEvery(UPDATE_EDIT_STATUS, function*(action) {
-    yield put(toggleSaveMode(action.hasChanged));
+    yield put(toggleSaveMode(action.hasUserEdits));
   });
 }
 

--- a/packages/veritone-widgets/src/redux/modules/mediaDetails/saga.js
+++ b/packages/veritone-widgets/src/redux/modules/mediaDetails/saga.js
@@ -12,7 +12,7 @@ import { modules } from 'veritone-redux-common';
 import { getFaceEngineAssetData, cancelFaceEdits } from './faceEngineOutput';
 import {
   getTranscriptEditAssetData,
-  RESET as TRANSCRIPT_RESET
+  reset as resetTranscript
 } from './transcriptWidget';
 const { auth: authModule, config: configModule } = modules;
 
@@ -760,7 +760,6 @@ function* createFileAssetSaga(
     }
     // Reset the the transcipt engine results.
     if (selectedEngineCategory.categoryType === 'transcript') {
-      yield put({ type: TRANSCRIPT_RESET });
       yield put(clearEngineResultsByEngineId(userGeneratedEngineId, widgetId));
     }
     yield put(toggleEditMode(widgetId, selectedEngineCategory));
@@ -1548,6 +1547,8 @@ function* watchCancelEdit() {
 
       if (selectedEngineCategory.categoryType === 'face') {
         yield put(cancelFaceEdits());
+      } else if (selectedEngineCategory.categoryType === 'transcript') {
+        yield put(resetTranscript());
       }
     }
   });

--- a/packages/veritone-widgets/src/redux/modules/mediaDetails/saga.js
+++ b/packages/veritone-widgets/src/redux/modules/mediaDetails/saga.js
@@ -80,8 +80,7 @@ import {
 } from '.';
 
 import {
-  ADD_DETECTED_FACE,
-  clearFaceEngineResultsByEngineId
+  ADD_DETECTED_FACE
 } from './faceEngineOutput';
 import { UPDATE_EDIT_STATUS } from './transcriptWidget';
 
@@ -772,8 +771,7 @@ function* createFileAssetSaga(
     // Reset the the transcipt engine results.
     if (selectedEngineCategory.categoryType === 'transcript') {
       yield put(clearEngineResultsByEngineId(userGeneratedEngineId, widgetId));
-    } else if (selectedEngineCategory.categoryType === 'face') {
-      yield put(clearFaceEngineResultsByEngineId(userGeneratedEngineId));
+    } else if (selectedEngineCategory.categoryType === 'face' && userGeneratedEngineId) {
       yield put(
         fetchFaceEngineResults({
           selectedEngineId: userGeneratedEngineId,

--- a/packages/veritone-widgets/src/redux/modules/mediaDetails/saga.js
+++ b/packages/veritone-widgets/src/redux/modules/mediaDetails/saga.js
@@ -12,7 +12,8 @@ import { modules } from 'veritone-redux-common';
 import {
   getFaceEngineAssetData,
   cancelFaceEdits,
-  fetchEngineResults as fetchFaceEngineResults
+  fetchEngineResults as fetchFaceEngineResults,
+  ADD_DETECTED_FACE
 } from './faceEngineOutput';
 import {
   getTranscriptEditAssetData,
@@ -79,9 +80,6 @@ import {
   getEngineCategories
 } from '.';
 
-import {
-  ADD_DETECTED_FACE
-} from './faceEngineOutput';
 import { UPDATE_EDIT_STATUS } from './transcriptWidget';
 
 const tdoInfoQueryClause = `id

--- a/packages/veritone-widgets/src/redux/modules/mediaDetails/transcriptWidget/index.js
+++ b/packages/veritone-widgets/src/redux/modules/mediaDetails/transcriptWidget/index.js
@@ -276,10 +276,10 @@ export const clearData = () => ({ type: CLEAR_DATA });
 export const receiveData = newData => ({ type: RECEIVE_DATA, data: newData });
 export const updateEditStatus = state => ({
   type: UPDATE_EDIT_STATUS,
-  hasChanged: this.hasChanged(state)
+  hasUserEdits: this.hasUserEdits(state)
 });
 export const currentData = state => get(state[transcriptNamespace], 'data');
-export const hasChanged = state => {
+export const hasUserEdits = state => {
   const history = get(state[transcriptNamespace], 'past');
   return history && history.length > 0;
 };

--- a/packages/veritone-widgets/src/redux/modules/mediaDetails/transcriptWidget/saga.js
+++ b/packages/veritone-widgets/src/redux/modules/mediaDetails/transcriptWidget/saga.js
@@ -2,6 +2,7 @@ import { get, isEqual } from 'lodash';
 import { delay } from 'redux-saga';
 import { fork, all, call, put, takeEvery, select } from 'redux-saga/effects';
 import * as TranscriptRedux from '.';
+import { DISCARD_UNSAVED_CHANGES } from '../index';
 
 const CHANGE_WITH_DEBOUNCE =
   TranscriptRedux.transcriptNamespace + '_CHANGE_WITH_DEBOUNCE';
@@ -108,6 +109,12 @@ function* watchContentReceiveData() {
   );
 }
 
+function* watchDiscardUnsavedChanges() {
+  yield takeEvery(DISCARD_UNSAVED_CHANGES, function*(action) {
+    yield call(TranscriptRedux.reset);
+  });
+}
+
 export const changeWidthDebounce = newData => ({
   data: newData,
   type: CHANGE_WITH_DEBOUNCE
@@ -120,6 +127,7 @@ export default function* transcriptSaga() {
     fork(watchContentReset),
     fork(watchContentChange),
     fork(watchContentClearData),
-    fork(watchContentReceiveData)
+    fork(watchContentReceiveData),
+    fork(watchDiscardUnsavedChanges)
   ]);
 }

--- a/packages/veritone-widgets/src/redux/modules/mediaDetails/transcriptWidget/saga.js
+++ b/packages/veritone-widgets/src/redux/modules/mediaDetails/transcriptWidget/saga.js
@@ -23,7 +23,7 @@ function* watchContentUndo() {
     if (state && past.length === 0) {
       yield put({
         type: TranscriptRedux.UPDATE_EDIT_STATUS,
-        hasChanged: false
+        hasUserEdits: false
       });
     }
   });
@@ -34,7 +34,7 @@ function* watchContentRedo() {
     action
   ) {
     yield call(TranscriptRedux.redo);
-    yield put({ type: TranscriptRedux.UPDATE_EDIT_STATUS, hasChanged: true });
+    yield put({ type: TranscriptRedux.UPDATE_EDIT_STATUS, hasUserEdits: true });
   });
 }
 
@@ -43,7 +43,7 @@ function* watchContentReset() {
     action
   ) {
     yield call(TranscriptRedux.reset);
-    yield put({ type: TranscriptRedux.UPDATE_EDIT_STATUS, hasChanged: false });
+    yield put({ type: TranscriptRedux.UPDATE_EDIT_STATUS, hasUserEdits: false });
   });
 }
 
@@ -65,7 +65,7 @@ function* watchContentChange() {
   ) {
     yield put({
       type: TranscriptRedux.UPDATE_EDIT_STATUS,
-      hasChanged: true
+      hasUserEdits: true
     });
 
     unsavedData = action.data;
@@ -87,7 +87,7 @@ function* watchContentClearData() {
       yield call(TranscriptRedux.clearData);
       yield put({
         type: TranscriptRedux.UPDATE_EDIT_STATUS,
-        hasChanged: false
+        hasUserEdits: false
       });
     }
   );
@@ -102,7 +102,7 @@ function* watchContentReceiveData() {
         yield call(TranscriptRedux.receiveData);
         yield put({
           type: TranscriptRedux.UPDATE_EDIT_STATUS,
-          hasChanged: true
+          hasUserEdits: true
         });
       }
     }

--- a/packages/veritone-widgets/src/widgets/MediaDetails/index.js
+++ b/packages/veritone-widgets/src/widgets/MediaDetails/index.js
@@ -56,7 +56,6 @@ import Tooltip from '@material-ui/core/Tooltip';
 import cx from 'classnames';
 import styles from './styles.scss';
 import * as mediaDetailsModule from '../../redux/modules/mediaDetails';
-import { reset } from '../../redux/modules/mediaDetails/transcriptWidget';
 import * as transcriptWidgetModule from '../../redux/modules/mediaDetails/transcriptWidget';
 import widget from '../../shared/widget';
 
@@ -106,7 +105,6 @@ import widget from '../../shared/widget';
     toggleExpandedMode: mediaDetailsModule.toggleExpandedMode,
     fetchApplications: applicationModule.fetchApplications,
     saveAssetData: mediaDetailsModule.saveAssetData,
-    resetTranscript: reset,
     openConfirmModal: mediaDetailsModule.openConfirmModal,
     closeConfirmModal: mediaDetailsModule.closeConfirmModal,
     discardUnsavedChanges: mediaDetailsModule.discardUnsavedChanges
@@ -258,7 +256,6 @@ class MediaDetailsWidget extends React.Component {
     saveAssetData: func,
     widgetError: string,
     isSaveEnabled: bool,
-    resetTranscript: func,
     alertDialogConfig: shape({
       show: bool,
       title: string,
@@ -412,7 +409,6 @@ class MediaDetailsWidget extends React.Component {
     if (this.props.isEditModeEnabled) {
       this.toggleEditMode();
     }
-    this.props.resetTranscript();
   };
 
   checkSaveSate = () => {

--- a/packages/veritone-widgets/src/widgets/MediaDetails/index.js
+++ b/packages/veritone-widgets/src/widgets/MediaDetails/index.js
@@ -56,7 +56,6 @@ import Tooltip from '@material-ui/core/Tooltip';
 import cx from 'classnames';
 import styles from './styles.scss';
 import * as mediaDetailsModule from '../../redux/modules/mediaDetails';
-import * as transcriptWidgetModule from '../../redux/modules/mediaDetails/transcriptWidget';
 import widget from '../../shared/widget';
 
 @withPropsOnChange([], ({ id }) => ({
@@ -89,8 +88,7 @@ import widget from '../../shared/widget';
     isSaveEnabled: mediaDetailsModule.isSaveEnabled(state),
     isUserGeneratedEngineId: mediaDetailsModule.isUserGeneratedEngineId,
     contextMenuExtensions: applicationModule.getContextMenuExtensions(state),
-    alertDialogConfig: mediaDetailsModule.getAlertDialogConfig(state, id),
-    transcriptHasChanged: transcriptWidgetModule.hasChanged(state)
+    alertDialogConfig: mediaDetailsModule.getAlertDialogConfig(state, id)
   }),
   {
     initializeWidget: mediaDetailsModule.initializeWidget,
@@ -266,8 +264,7 @@ class MediaDetailsWidget extends React.Component {
     }),
     openConfirmModal: func,
     closeConfirmModal: func,
-    discardUnsavedChanges: func,
-    transcriptHasChanged: bool
+    discardUnsavedChanges: func
   };
 
   static contextTypes = {
@@ -412,8 +409,7 @@ class MediaDetailsWidget extends React.Component {
   };
 
   checkSaveSate = () => {
-    // TODO: check for face changes.
-    if (this.props.transcriptHasChanged) {
+    if (this.props.isSaveEnabled) {
       this.props.openConfirmModal(this.onSaveEdit, this.props.id);
     } else {
       this.onCancelEdit();

--- a/packages/veritone-widgets/src/widgets/MediaDetails/index.js
+++ b/packages/veritone-widgets/src/widgets/MediaDetails/index.js
@@ -403,7 +403,6 @@ class MediaDetailsWidget extends React.Component {
       selectedEngineCategory: this.props.selectedEngineCategory
     });
     this.props.closeConfirmModal(this.props.id);
-    this.toggleEditMode();
   };
 
   onCancelEdit = () => {

--- a/packages/veritone-widgets/src/widgets/MediaDetails/index.js
+++ b/packages/veritone-widgets/src/widgets/MediaDetails/index.js
@@ -408,7 +408,7 @@ class MediaDetailsWidget extends React.Component {
     }
   };
 
-  checkSaveSate = () => {
+  checkSaveState = () => {
     if (this.props.isSaveEnabled) {
       this.props.openConfirmModal(this.onSaveEdit, this.props.id);
     } else {
@@ -971,7 +971,7 @@ class MediaDetailsWidget extends React.Component {
                 <div className={styles.pageHeaderEditMode}>
                   <IconButton
                     className={styles.backButtonEditMode}
-                    onClick={this.checkSaveSate}
+                    onClick={this.checkSaveState}
                     aria-label="Back"
                   >
                     <Icon
@@ -998,7 +998,7 @@ class MediaDetailsWidget extends React.Component {
                     {isEditModeEnabled && (
                       <Button
                         className={styles.actionButtonEditMode}
-                        onClick={this.checkSaveSate}
+                        onClick={this.checkSaveState}
                       >
                         CANCEL
                       </Button>

--- a/packages/veritone-widgets/src/widgets/TranscriptEngineOutputWidget/index.js
+++ b/packages/veritone-widgets/src/widgets/TranscriptEngineOutputWidget/index.js
@@ -1,6 +1,6 @@
 import React, { Component, Fragment } from 'react';
 import { number, bool, string, func, shape, arrayOf, node } from 'prop-types';
-import { isEqual } from 'lodash';
+import { isEqual, noop } from 'lodash';
 
 import { connect } from 'react-redux';
 import { util } from 'veritone-redux-common';
@@ -104,7 +104,8 @@ export default class TranscriptEngineOutputWidget extends Component {
   state = {
     alert: false,
     editMode: TranscriptEditMode.SNIPPET,
-    props: this.props
+    props: this.props,
+    alertConfirmAction: noop
   };
 
   static getDerivedStateFromProps(nextProps, prevState) {
@@ -124,10 +125,12 @@ export default class TranscriptEngineOutputWidget extends Component {
   };
 
   handleOnEditModeChange = value => {
-    if (this.props.hasChanged) {
+    if (this.props.editMode && this.props.hasChanged) {
       this.setState({
         alert: true,
-        pendingEditMode: value.type
+        alertConfirmAction: () => {
+          this.setState({editMode: value.type});
+        }
       });
     } else {
       this.setState({
@@ -137,23 +140,34 @@ export default class TranscriptEngineOutputWidget extends Component {
     }
   };
 
-  handleAlertConfirm = value => {
-    if (value === 'cancel') {
+  handleEngineChange = engineId => {
+    if (this.props.editMode && this.props.hasChanged) {
       this.setState({
-        alert: false
+        alert: true,
+        alertConfirmAction: () => {
+          this.props.onEngineChange(engineId)
+        }
       });
     } else {
-      // value = approve
-      this.props.reset();
-      this.setState(prevState => {
-        return {
-          alert: false,
-          editMode: prevState.pendingEditMode,
-          pendingEditMode: undefined
-        };
-      });
+      this.props.onEngineChange(engineId);
     }
+  }
+
+  handleAlertConfirm = () => {
+    this.props.reset();
+    this.state.alertConfirmAction();
+    this.setState({
+      alert: false,
+      alertConfirmAction: noop
+    });
   };
+  
+  handleAlertCancel = () => {
+    this.setState({
+      alert: false,
+      alertConfirmAction: noop
+    });
+  }
 
   render() {
     const {
@@ -167,7 +181,6 @@ export default class TranscriptEngineOutputWidget extends Component {
       editMode,
       onClick,
       onScroll,
-      onEngineChange,
       onExpandClicked,
       mediaLengthMs,
       neglectableTimeMs,
@@ -200,7 +213,7 @@ export default class TranscriptEngineOutputWidget extends Component {
           onEditTypeChange={this.handleOnEditModeChange}
           onClick={onClick}
           onScroll={onScroll}
-          onEngineChange={onEngineChange}
+          onEngineChange={this.handleEngineChange}
           onExpandClicked={onExpandClicked}
           mediaLengthMs={mediaLengthMs}
           neglectableTimeMs={neglectableTimeMs}
@@ -216,7 +229,7 @@ export default class TranscriptEngineOutputWidget extends Component {
           content={alertDescription}
           cancelButtonLabel={cancelButtonLabel}
           approveButtonLabel={approveButtonLabel}
-          onCancel={this.handleAlertConfirm}
+          onCancel={this.handleAlertCancel}
           onApprove={this.handleAlertConfirm}
         />
       </Fragment>

--- a/packages/veritone-widgets/src/widgets/TranscriptEngineOutputWidget/index.js
+++ b/packages/veritone-widgets/src/widgets/TranscriptEngineOutputWidget/index.js
@@ -129,7 +129,7 @@ export default class TranscriptEngineOutputWidget extends Component {
       this.setState({
         alert: true,
         alertConfirmAction: () => {
-          this.setState({editMode: value.type});
+          this.setState({ editMode: value.type });
         }
       });
     } else {
@@ -145,13 +145,13 @@ export default class TranscriptEngineOutputWidget extends Component {
       this.setState({
         alert: true,
         alertConfirmAction: () => {
-          this.props.onEngineChange(engineId)
+          this.props.onEngineChange(engineId);
         }
       });
     } else {
       this.props.onEngineChange(engineId);
     }
-  }
+  };
 
   handleAlertConfirm = () => {
     this.props.reset();
@@ -161,13 +161,13 @@ export default class TranscriptEngineOutputWidget extends Component {
       alertConfirmAction: noop
     });
   };
-  
+
   handleAlertCancel = () => {
     this.setState({
       alert: false,
       alertConfirmAction: noop
     });
-  }
+  };
 
   render() {
     const {

--- a/packages/veritone-widgets/src/widgets/TranscriptEngineOutputWidget/index.js
+++ b/packages/veritone-widgets/src/widgets/TranscriptEngineOutputWidget/index.js
@@ -19,7 +19,7 @@ const saga = util.reactReduxSaga.saga;
 @saga(transcriptSaga)
 @connect(
   state => ({
-    hasChanged: TranscriptRedux.hasChanged(state),
+    hasUserEdits: TranscriptRedux.hasUserEdits(state),
     currentData: TranscriptRedux.currentData(state)
   }),
   {
@@ -96,7 +96,7 @@ export default class TranscriptEngineOutputWidget extends Component {
     change: func.isRequired,
     clearData: func.isRequired,
     receiveData: func.isRequired,
-    hasChanged: bool,
+    hasUserEdits: bool,
     outputNullState: node,
     bulkEditEnabled: bool
   };
@@ -125,7 +125,7 @@ export default class TranscriptEngineOutputWidget extends Component {
   };
 
   handleOnEditModeChange = value => {
-    if (this.props.editMode && this.props.hasChanged) {
+    if (this.props.editMode && this.props.hasUserEdits) {
       this.setState({
         alert: true,
         alertConfirmAction: () => {
@@ -141,7 +141,7 @@ export default class TranscriptEngineOutputWidget extends Component {
   };
 
   handleEngineChange = engineId => {
-    if (this.props.editMode && this.props.hasChanged) {
+    if (this.props.editMode && this.props.hasUserEdits) {
       this.setState({
         alert: true,
         alertConfirmAction: () => {


### PR DESCRIPTION
In certain scenarios when a user is editing a transcript or face engine output we need to warn them that their edits will be removed if they perform certain actions.

If the user has made edits and they hit the cancel or back button it should display a modal that asks them if they want to save their changes.

If they are in face or transcript and they change the engine id we need to warn them that their changes will be lost.

In transcript if they change the edit mode it should warn them that their changes will be lost.