### PR TITLE
fix selected engines not initializing across widgets and hoist results

### DIFF
--- a/packages/veritone-widgets/src/redux/modules/engineSelection/index.js
+++ b/packages/veritone-widgets/src/redux/modules/engineSelection/index.js
@@ -32,7 +32,6 @@ export const SET_ALL_ENGINES_SELECTED =
 export const namespace = 'engineSelection';
 
 const defaultSelectionState = {
-  searchResults: {},
   searchQuery: '',
   filters: {
     category: [],
@@ -47,7 +46,6 @@ const defaultSelectionState = {
   deselectedEngineIds: [],
   allEnginesSelected: false
 };
-
 const defaultState = {
   // populated like:
   // [pickerId]: { ...defaultPickerState }
@@ -57,6 +55,7 @@ export default createReducer(defaultState, {
   [INITIALIZE_WIDGET](state, action) {
     return {
       ...defaultState,
+      searchResults: state.searchResults || {},
       [action.meta.id]: {
         ...defaultSelectionState
       }
@@ -79,12 +78,12 @@ export default createReducer(defaultState, {
 
     return {
       ...state,
+      searchResults: merge({}, state.searchResults, newResults),
       [id]: {
         ...state[id],
         selectedEngineIds: [
           ...new Set([...state[id].selectedEngineIds, ...selectedEngineIds])
-        ],
-        searchResults: merge({}, state[id].searchResults, newResults)
+        ]
       }
     };
   },
@@ -471,7 +470,7 @@ export function isSearchOpen(state, id) {
 
 export function getCurrentResults(state, id) {
   const results = get(
-    get(local(state), [id, 'searchResults']),
+    get(local(state), 'searchResults'),
     pathFor(
       get(local(state), [id, 'searchQuery']),
       get(local(state), [id, 'filters'])

--- a/packages/veritone-widgets/src/widgets/EngineSelection/EngineListView/index.js
+++ b/packages/veritone-widgets/src/widgets/EngineSelection/EngineListView/index.js
@@ -29,10 +29,8 @@ import styles from './styles.scss';
 
 @connect(
   (state, { id }) => ({
-    allEngines: engineModule.getEngines(state, id),
     currentResults: engineSelectionModule.getCurrentResults(state, id),
     allEnginesChecked: engineSelectionModule.allEnginesChecked(state, id),
-    selectedEngineIds: engineSelectionModule.getSelectedEngineIds(state, id),
     checkedEngineIds: engineSelectionModule.getCheckedEngineIds(state, id),
     isFetchingEngines: engineModule.isFetchingEngines(state, id),
     failedToFetchEngines: engineModule.failedToFetchEngines(state, id),
@@ -87,7 +85,6 @@ export default class EngineListView extends React.Component {
   };
 
   static defaultProps = {
-    allEngines: {},
     currentResults: []
   };
 

--- a/packages/veritone-widgets/src/widgets/EngineSelection/index.js
+++ b/packages/veritone-widgets/src/widgets/EngineSelection/index.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { func, arrayOf, string, bool, shape } from 'prop-types';
+import { func, arrayOf, string, bool, shape, objectOf, object } from 'prop-types';
+import { isEmpty } from 'lodash';
 import { withMuiThemeProvider } from 'veritone-react-common';
+import { modules } from 'veritone-redux-common';
+const { engine: engineModule } = modules;
 
 import EngineListView from './EngineListView/';
 import EngineDetailView from './EngineDetailView/';
@@ -13,6 +16,7 @@ import widget from '../../shared/widget';
 @withMuiThemeProvider
 @connect(
   (state, { _widgetId }) => ({
+    allEngines: engineModule.getEngines(state, _widgetId),
     deselectedEngineIds: engineSelectionModule.getDeselectedEngineIds(
       state,
       _widgetId
@@ -25,6 +29,7 @@ import widget from '../../shared/widget';
   {
     initializeWidget: engineSelectionModule.initializeWidget,
     fetchEngines: engineSelectionModule.refetchEngines,
+    selectEngines: engineSelectionModule.selectEngines,
     setDeselectedEngineIds: engineSelectionModule.setDeselectedEngineIds,
     setAllEnginesSelected: engineSelectionModule.setAllEnginesSelected
   },
@@ -52,10 +57,14 @@ class EngineSelection extends React.Component {
     initialSelectedEngineIds: arrayOf(string),
     selectedEngineIds: arrayOf(string),
     deselectedEngineIds: arrayOf(string),
+    allEngines: objectOf(object),
+    selectEngines: func.isRequired,
     hideActions: bool
   };
 
   static defaultProps = {
+    allEngines: {},
+    selectedEngineIds: [],
     initialSelectedEngineIds: [],
     initialDeselectedEngineIds: [],
     allEnginesSelected: false,
@@ -80,7 +89,12 @@ class EngineSelection extends React.Component {
       this.props._widgetId,
       this.props.allEnginesSelected
     );
-    this.props.fetchEngines(this.props._widgetId);
+
+    if (isEmpty(this.props.allEngines)) {
+      this.props.fetchEngines(this.props._widgetId);
+    } else {
+      this.props.selectEngines(this.props._widgetId, this.props.initialSelectedEngineIds)
+    }
   }
 
   save = () => {
@@ -123,7 +137,9 @@ class EngineSelection extends React.Component {
         onSave={this.save}
         onCancel={this.props.onCancel}
         actionMenuItems={this.props.actionMenuItems}
+        allEngines={this.props.allEngines}
         allEnginesSelected={this.props.allEnginesSelected}
+        selectedEngineIds={this.props.selectedEngineIds}
         hideActions={this.props.hideActions}
         initialSelectedEngineIds={this.props.initialSelectedEngineIds}
       />


### PR DESCRIPTION
Fixes issue where selected engines are not reinitialized across multiple widgets, and optimizes searchResults by hosting the tree outside of each widget.