### PR TITLE
Moved engine results redux code to veritone-redux-common

### DIFF
--- a/packages/veritone-react-common/src/components/EngineCategorySelector/index.js
+++ b/packages/veritone-react-common/src/components/EngineCategorySelector/index.js
@@ -56,8 +56,7 @@ export default class EngineCategorySelector extends Component {
                     }
                     classes={{
                       root: styles.engineCategoryTab,
-                      selected:
-                        styles.engineCategoryTabSelectedColor
+                      selected: styles.engineCategoryTabSelectedColor
                     }}
                   />
                 );

--- a/packages/veritone-react-common/src/components/EngineCategorySelector/story.js
+++ b/packages/veritone-react-common/src/components/EngineCategorySelector/story.js
@@ -4,33 +4,32 @@ import { action } from '@storybook/addon-actions';
 
 import EngineCategorySelector from './';
 
-storiesOf('EngineCategorySelector', module)
-  .add('Base', () => {
-    const TRANSCRIPT_ENGINE_CATEGORY = {
-      id: '67cd4dd0-2f75-445d-a6f0-2f297d6cd182',
-      name: 'Transcription',
-      iconClass: 'icon-transcription',
-      engines: [],
-      editable: true,
-      status: 'completed',
-      categoryType: 'transcript'
-    };
-    const FACE_ENGINE_CATEGORY = {
-      id: '6faad6b7-0837-45f9-b161-2f6bf31b7a07',
-      name: 'Facial Detection',
-      iconClass: 'icon-face',
-      engines: [],
-      editable: true,
-      status: 'failed',
-      categoryType: 'face'
-    };
-    const engineCategories = [TRANSCRIPT_ENGINE_CATEGORY, FACE_ENGINE_CATEGORY];
+storiesOf('EngineCategorySelector', module).add('Base', () => {
+  const TRANSCRIPT_ENGINE_CATEGORY = {
+    id: '67cd4dd0-2f75-445d-a6f0-2f297d6cd182',
+    name: 'Transcription',
+    iconClass: 'icon-transcription',
+    engines: [],
+    editable: true,
+    status: 'completed',
+    categoryType: 'transcript'
+  };
+  const FACE_ENGINE_CATEGORY = {
+    id: '6faad6b7-0837-45f9-b161-2f6bf31b7a07',
+    name: 'Facial Detection',
+    iconClass: 'icon-face',
+    engines: [],
+    editable: true,
+    status: 'failed',
+    categoryType: 'face'
+  };
+  const engineCategories = [TRANSCRIPT_ENGINE_CATEGORY, FACE_ENGINE_CATEGORY];
 
-    return (
-      <EngineCategorySelector
-        engineCategories={engineCategories}
-        selectedEngineCategoryId={engineCategories[0].id}
-        onSelectEngineCategory={action('onSelectEngineCategory')}
-      />
-    );
-  });
+  return (
+    <EngineCategorySelector
+      engineCategories={engineCategories}
+      selectedEngineCategoryId={engineCategories[0].id}
+      onSelectEngineCategory={action('onSelectEngineCategory')}
+    />
+  );
+});

--- a/packages/veritone-react-common/src/components/EngineOutputHeader/index.js
+++ b/packages/veritone-react-common/src/components/EngineOutputHeader/index.js
@@ -38,7 +38,10 @@ class EngineOutputHeader extends Component {
   };
 
   handleEngineChange = evt => {
-    if (this.props.onEngineChange) {
+    if (
+      this.props.onEngineChange &&
+      this.props.selectedEngineId !== evt.target.value
+    ) {
       this.props.onEngineChange(evt.target.value);
     }
   };

--- a/packages/veritone-react-common/src/components/EngineOutputNullState/index.js
+++ b/packages/veritone-react-common/src/components/EngineOutputNullState/index.js
@@ -8,8 +8,10 @@ import { includes } from 'lodash';
 import withMuiThemeProvider from 'helpers/withMuiThemeProvider';
 import styles from './styles.scss';
 
-const errorRunningEngineImage = '//static.veritone.com/veritone-ui/engine-error-red.svg';
-const warningNoOutputDataImage = '//static.veritone.com/veritone-ui/warning-icon-lg.svg';
+const errorRunningEngineImage =
+  '//static.veritone.com/veritone-ui/engine-error-red.svg';
+const warningNoOutputDataImage =
+  '//static.veritone.com/veritone-ui/warning-icon-lg.svg';
 
 @withMuiThemeProvider
 export default class EngineOutputNullState extends Component {

--- a/packages/veritone-react-common/src/components/ExpandableInputField/index.js
+++ b/packages/veritone-react-common/src/components/ExpandableInputField/index.js
@@ -52,10 +52,7 @@ class ExpandableInputField extends React.Component {
   };
 
   onKeyPress = evt => {
-    if (
-      evt.key === 'Enter' &&
-      this.props.onSearch
-    ) {
+    if (evt.key === 'Enter' && this.props.onSearch) {
       this.props.onSearch(evt.target.value);
     }
   };

--- a/packages/veritone-react-common/src/components/FaceEngineOutput/EntityInformation/index.js
+++ b/packages/veritone-react-common/src/components/FaceEngineOutput/EntityInformation/index.js
@@ -60,7 +60,9 @@ class EntityInformation extends Component {
           className={styles.entityBackButton}
           onClick={onBackClicked}
         >
-          <Icon className={classNames(styles.entityBackIcon, 'icon-arrow-back')} />
+          <Icon
+            className={classNames(styles.entityBackIcon, 'icon-arrow-back')}
+          />
           <span className={styles.entityBackLabel}>Back</span>
         </Button>
         <div className={styles.selectedEntity}>
@@ -87,8 +89,16 @@ class EntityInformation extends Component {
             onChange={this.handleTabChange}
             indicatorColor="primary"
           >
-            <Tab label="Matched in this Video" value="faceMatches" classes={{root: styles.infoTab}}/>
-            <Tab label="Metadata" value="metadata" classes={{root: styles.infoTab}}/>
+            <Tab
+              label="Matched in this Video"
+              value="faceMatches"
+              classes={{ root: styles.infoTab }}
+            />
+            <Tab
+              label="Metadata"
+              value="metadata"
+              classes={{ root: styles.infoTab }}
+            />
           </Tabs>
           {this.state.activeTab === 'faceMatches' && (
             <div className={styles.tabContainer}>

--- a/packages/veritone-react-common/src/components/FaceEngineOutput/FaceDetectionBox/index.js
+++ b/packages/veritone-react-common/src/components/FaceEngineOutput/FaceDetectionBox/index.js
@@ -138,7 +138,7 @@ class FaceDetectionBox extends Component {
         editFaceEntity: false
       });
     }
-  }
+  };
 
   calculatePopperPlacement = () => {
     let shift = 'start';

--- a/packages/veritone-react-common/src/components/FaceEngineOutput/FacesByScene/index.js
+++ b/packages/veritone-react-common/src/components/FaceEngineOutput/FacesByScene/index.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { arrayOf, shape, number, string, func } from 'prop-types';
 
 import withMuiThemeProvider from 'helpers/withMuiThemeProvider';
@@ -92,7 +92,7 @@ class FacesByScene extends Component {
         {!recognizedEntityObjects.length ? (
           <NoFacesFound />
         ) : (
-          <div>{recognizedEntityObjects}</div>
+          <Fragment>{recognizedEntityObjects}</Fragment>
         )}
       </div>
     );

--- a/packages/veritone-react-common/src/components/FaceEngineOutput/index.js
+++ b/packages/veritone-react-common/src/components/FaceEngineOutput/index.js
@@ -101,6 +101,15 @@ class FaceEngineOutput extends Component {
     viewMode: 'summary'
   };
 
+  static getDerivedStateFromProps(nextProps, state) {
+    if (nextProps.editMode && state.viewMode !== 'summary') {
+      return {
+        viewMode: 'summary'
+      };
+    }
+    return null;
+  }
+
   handleTabChange = (event, activeTab) => {
     if (activeTab !== this.state.activeTab) {
       this.setState({ activeTab });

--- a/packages/veritone-react-common/src/components/FaceEngineOutput/story.js
+++ b/packages/veritone-react-common/src/components/FaceEngineOutput/story.js
@@ -17,13 +17,213 @@ import {
   number as knobNumber
 } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
-import { isEqual, isEmpty, find } from 'lodash';
+import { isEmpty, find, cloneDeep } from 'lodash';
+import  { guid } from 'helpers/guid';
 
 import EngineOutputNullState from '../EngineOutputNullState';
 
 import styles from './story.styles.scss';
 
 import FaceEngineOutput from './';
+
+const faces = [
+  {
+    uri: 'https://images.radio-online.com/images/logos/Veritonexl.png',
+    boundingPoly: [
+      {
+        x: 0.5,
+        y: 0.2
+      },
+      {
+        x: 0.7,
+        y: 0.4
+      }
+    ]
+  },
+  {
+    uri: 'https://images.radio-online.com/images/logos/Veritonexl.png',
+    boundingPoly: [
+      {
+        x: 0.1,
+        y: 0.2
+      },
+      {
+        x: 0.5,
+        y: 0.5
+      }
+    ]
+  },
+  {
+    uri: 'https://images.radio-online.com/images/logos/Veritonexl.png',
+    boundingPoly: [
+      {
+        x: 0.4,
+        y: 0.2
+      },
+      {
+        x: 0.8,
+        y: 0.6
+      }
+    ]
+  },
+  {
+    uri: 'https://images.radio-online.com/images/logos/Veritonexl.png',
+    boundingPoly: [
+      {
+        x: 0.4,
+        y: 0.1
+      },
+      {
+        x: 0.9,
+        y: 0.4
+      }
+    ]
+  },
+  {
+    uri: 'https://images.radio-online.com/images/logos/Veritonexl.png',
+    boundingPoly: [
+      {
+        x: 0.2,
+        y: 0.5
+      },
+      {
+        x: 0.5,
+        y: 0.9
+      }
+    ]
+  },
+  {
+    uri: 'https://images.radio-online.com/images/logos/Veritonexl.png',
+    boundingPoly: [
+      {
+        x: 0.3,
+        y: 0.4
+      },
+      {
+        x: 0.8,
+        y: 0.8
+      }
+    ]
+  },
+  {
+    uri: 'https://images.radio-online.com/images/logos/Veritonexl.png',
+    boundingPoly: [
+      {
+        x: 0.4,
+        y: 0.3
+      },
+      {
+        x: 0.8,
+        y: 0.6
+      }
+    ]
+  },
+  {
+    uri: 'https://images.radio-online.com/images/logos/Veritonexl.png',
+    boundingPoly: [
+      {
+        x: 0.5,
+        y: 0.6
+      },
+      {
+        x: 0.8,
+        y: 0.8
+      }
+    ]
+  }
+];
+
+const entities = [
+  {
+    id: 'c36e8b95-6d46-4a5a-a272-8507319a5a54',
+    name: 'Paul McCartney',
+    libraryId: 'f1297e1c-9c20-48fa-a8fd-46f1e6d62c43',
+    library: {
+      id: 'f1297e1c-9c20-48fa-a8fd-46f1e6d62c43',
+      name: 'Beatles'
+    },
+    profileImageUrl:
+      'https://pbs.twimg.com/profile_images/806883889146957824/VbnEycIm_normal.jpg',
+    jsondata: {
+      name: 'Paul McCartney',
+      middleName: 'Bob',
+      age: 75,
+      gender: 'Male',
+      description:
+        'A member of the beatles. I am typing this to test a long string that will be used in a description for this person or not.'
+    }
+  },
+  {
+    id: '1945a3ba-f0a3-411e-8419-78e31c73150a',
+    name: 'Ringo Starr',
+    libraryId: 'abc',
+    library: {
+      id: 'abc',
+      name: 'Test Library 2'
+    },
+    profileImageUrl: null,
+    jsondata: {}
+  },
+  {
+    id: '8e35f28c-34aa-4ee3-8690-f62bf1a704fa',
+    name: 'George Harrison',
+    libraryId: 'f1297e1c-9c20-48fa-a8fd-46f1e6d62c43',
+    library: {
+      id: 'f1297e1c-9c20-48fa-a8fd-46f1e6d62c43',
+      name: 'Beatles'
+    },
+    profileImageUrl:
+      'http://www.slate.com/content/dam/slate/articles/arts/musicbox/2011/10/111004_MUSIC_harrisonFW.jpg.CROP.article250-medium.jpg',
+    jsondata: {
+      description: ''
+    }
+  },
+  {
+    id: '13595602-3a7f-48d3-bfde-2d029af479f6',
+    name: 'Gomez Addams',
+    libraryId: 'b64ef50a-0a5b-47ff-a403-a9a30f9241a4',
+    library: {
+      id: 'b64ef50a-0a5b-47ff-a403-a9a30f9241a4',
+      name: 'Addams Family'
+    },
+    profileImage: null,
+    jsondata: {}
+  },
+  {
+    id: 'c1666e9f-9dc0-40f9-aece-0ec1bfeae29a',
+    name: 'James Williams',
+    libraryId: '123',
+    library: {
+      id: '123',
+      name: 'Test Library'
+    },
+    profileImage: null,
+    jsondata: {}
+  }
+];
+
+const libraries = [
+  {
+    id: 'f1297e1c-9c20-48fa-a8fd-46f1e6d62c43',
+    name: 'Beatles'
+  },
+  {
+    id: 'b64ef50a-0a5b-47ff-a403-a9a30f9241a4',
+    name: 'Addams Family'
+  },
+  {
+    id: '123',
+    name: 'Test Library'
+  },
+  {
+    id: 'abc',
+    name: 'Test Library 2'
+  }
+];
+
+const tdoLength = 100000, interval = 1000;
+
+const faceObjects = genFaceObjects(0, tdoLength, interval, faces, entities);
 
 class FaceEngineOutputStory extends Component {
   static propTypes = {
@@ -32,6 +232,7 @@ class FaceEngineOutputStory extends Component {
     onAddNewEntity: func,
     onFaceOccurrenceClicked: func,
     onRemoveFaceDetection: func,
+    onUpdateFaceDetection: func,
     entities: arrayOf(
       shape({
         id: string,
@@ -46,11 +247,10 @@ class FaceEngineOutputStory extends Component {
   };
 
   state = {
-    facesDetectedByUser: {},
+    unrecognizedFaces: [],
+    recognizedFaces: {},
     entitySearchResults: [],
     entities: this.props.entities,
-    engineResultsByEngineId: {},
-    fetchedEngineResults: {},
     engines: [
       {
         id: 'f44aa80e-4650-c55c-58e7-49c965019790',
@@ -101,53 +301,6 @@ class FaceEngineOutputStory extends Component {
     };
   }
 
-  handleRemoveFaceDetection = face => {
-    this.setState(prevState => ({
-      unrecognizedFaces: prevState.unrecognizedFaces.filter(faceObj => {
-        return !isEqual(face, faceObj);
-      })
-    }));
-    this.props.onRemoveFaceDetection(face);
-  };
-
-  handleUpdateFace = (face, entity) => {
-    this.setState(prevState => {
-      return {
-        faceEngineOutput: prevState.faceEngineOutput.map(output => {
-          if (
-            face.startTimeMs >= output.series[0].startTimeMs &&
-            face.stopTimeMs <=
-              output.series[output.series.length - 1].stopTimeMs
-          ) {
-            return {
-              ...output,
-              series: output.series.map(faceObj => {
-                if (isEqual(face, faceObj)) {
-                  return {
-                    ...face,
-                    object: {
-                      ...face.object,
-                      entityId: entity.id,
-                      libraryId: entity.libraryId
-                    }
-                  };
-                }
-                return { ...faceObj };
-              })
-            };
-          }
-          return {
-            ...output
-          };
-        }),
-        modifiedFaces: [
-          ...prevState.modifiedFaces,
-          { ...face, modification: 'update' }
-        ]
-      };
-    });
-  };
-
   searchForEntities = searchQuery => {
     if (searchQuery && searchQuery.length) {
       const searchRegex = new RegExp(searchQuery, 'gi');
@@ -169,7 +322,9 @@ class FaceEngineOutputStory extends Component {
       mediaPlayerPosition,
       onAddNewEntity,
       onFaceOccurrenceClicked,
-      showNullState
+      showNullState,
+      onRemoveFaceDetection,
+      onUpdateFaceDetection
     } = this.props;
 
     return (
@@ -187,8 +342,8 @@ class FaceEngineOutputStory extends Component {
         editMode={editMode}
         entitySearchResults={this.state.entitySearchResults}
         onAddNewEntity={onAddNewEntity}
-        onRemoveFaceDetection={this.handleRemoveFaceDetection}
-        onEditFaceDetection={this.handleUpdateFace}
+        onRemoveFaceDetection={onRemoveFaceDetection}
+        onEditFaceDetection={onUpdateFaceDetection}
         onSearchForEntities={this.searchForEntities}
         outputNullState={
           showNullState && (
@@ -216,234 +371,52 @@ storiesOf('FaceEngineOutput', module)
         mediaPlayerPosition={knobNumber('mediaPlayerPosition', 0, {
           range: true,
           min: 0,
-          max: 6000,
-          step: 1000
+          max: tdoLength,
+          step: interval
         })}
         showNullState={boolean('showNullState', false)}
         onAddNewEntity={action('Pop the add new entity modal')}
         onFaceOccurrenceClicked={action('Set the media player position')}
         onRemoveFaceDetection={action('Remove face detection')}
+        onUpdateFaceDetection={action('Update face detection')}
       />
     );
   });
 
-const faceObjects = [
-  {
-    series: [
-      {
-        startTimeMs: 0,
-        stopTimeMs: 2000,
-        object: {
-          type: 'face',
-          uri: 'https://images.radio-online.com/images/logos/Veritonexl.png',
-          boundingPoly: [
-            {
-              x: 0.5,
-              y: 0.2
-            }
-          ]
-        }
-      },
-      {
-        startTimeMs: 1000,
-        stopTimeMs: 4000,
-        object: {
-          type: 'face',
-          uri: 'https://images.radio-online.com/images/logos/Veritonexl.png',
-          entityId: '13595602-3a7f-48d3-bfde-2d029af479f6',
-          libraryId: 'b64ef50a-0a5b-47ff-a403-a9a30f9241a4',
-          boundingPoly: [
-            {
-              x: 0.1,
-              y: 0.2
-            }
-          ],
-          confidence: 0.81
-        }
-      },
-      {
-        startTimeMs: 1000,
-        stopTimeMs: 4000,
-        object: {
-          type: 'face',
-          uri: 'https://images.radio-online.com/images/logos/Veritonexl.png',
-          entityId: '1945a3ba-f0a3-411e-8419-78e31c73150a',
-          libraryId: 'f1297e1c-9c20-48fa-a8fd-46f1e6d62c43',
-          boundingPoly: [
-            {
-              x: 0.4,
-              y: 0.2
-            }
-          ],
-          confidence: 0.81
-        }
-      },
-      {
-        startTimeMs: 1000,
-        stopTimeMs: 2000,
-        object: {
-          type: 'face',
-          uri: 'https://images.radio-online.com/images/logos/Veritonexl.png',
-          entityId: 'c36e8b95-6d46-4a5a-a272-8507319a5a54',
-          libraryId: 'f1297e1c-9c20-48fa-a8fd-46f1e6d62c43',
-          boundingPoly: [
-            {
-              x: 0.3,
-              y: 0.4
-            }
-          ],
-          confidence: 0.9
-        }
-      },
-      {
-        startTimeMs: 2000,
-        stopTimeMs: 3000,
-        object: {
-          type: 'face',
-          uri: 'https://images.radio-online.com/images/logos/Veritonexl.png',
-          entityId: '8e35f28c-34aa-4ee3-8690-f62bf1a704fa',
-          libraryId: 'f1297e1c-9c20-48fa-a8fd-46f1e6d62c43',
-          boundingPoly: [
-            {
-              x: 0.2,
-              y: 0.5
-            }
-          ],
-          confidence: 0.86
-        }
-      },
-      {
-        startTimeMs: 3000,
-        stopTimeMs: 4000,
-        object: {
-          type: 'face',
-          uri: 'https://images.radio-online.com/images/logos/Veritonexl.png',
-          entityId: 'c36e8b95-6d46-4a5a-a272-8507319a5a54',
-          libraryId: 'f1297e1c-9c20-48fa-a8fd-46f1e6d62c43',
-          boundingPoly: [
-            {
-              x: 0.3,
-              y: 0.4
-            }
-          ],
-          confidence: 0.9
-        }
-      }
-    ]
-  },
-  {
-    series: [
-      {
-        startTimeMs: 4000,
-        stopTimeMs: 6000,
-        object: {
-          type: 'face',
-          uri: 'https://images.radio-online.com/images/logos/Veritonexl.png',
-          boundingPoly: [
-            {
-              x: 0.4,
-              y: 0.3
-            }
-          ]
-        }
-      },
-      {
-        startTimeMs: 5000,
-        stopTimeMs: 6000,
-        object: {
-          type: 'face',
-          uri: 'https://images.radio-online.com/images/logos/Veritonexl.png',
-          entityId: '13595602-3a7f-48d3-bfde-2d029af479f6',
-          libraryId: 'b64ef50a-0a5b-47ff-a403-a9a30f9241a4',
-          boundingPoly: [
-            {
-              x: 0.5,
-              y: 0.2
-            }
-          ],
-          confidence: 0.94
-        }
-      }
-    ]
-  }
-];
-
-const entities = [
-  {
-    id: 'c36e8b95-6d46-4a5a-a272-8507319a5a54',
-    name: 'Paul McCartney',
-    libraryId: 'f1297e1c-9c20-48fa-a8fd-46f1e6d62c43',
-    library: {
-      id: 'f1297e1c-9c20-48fa-a8fd-46f1e6d62c43',
-      name: 'Beatles'
-    },
-    profileImageUrl:
-      'https://pbs.twimg.com/profile_images/806883889146957824/VbnEycIm_normal.jpg',
-    jsondata: {
-      name: 'Paul McCartney',
-      middleName: 'Bob',
-      age: 75,
-      gender: 'Male',
-      description:
-        'A member of the beatles. I am typing this to test a long string that will be used in a description for this person or not.'
+function genFaceObjects(
+  startTime,
+  stopTime,
+  timeInterval,
+  faces,
+  entities
+) {
+  const series = [];
+  const numEntries = Math.ceil((stopTime - startTime) / timeInterval);
+  for (let entryIndex = 0; entryIndex < numEntries; entryIndex++) {
+    const entryStartTime = startTime + entryIndex * timeInterval;
+    const randomFaceIndex = Math.round(Math.random() * (faces.length - 1));
+    const faceItem = cloneDeep(faces[randomFaceIndex]);
+    const isEntity = Math.floor(Math.random() * 5) === 0;
+    if (isEntity) {
+      const randomEntityIndex = Math.round(Math.random() * (entities.length - 1));
+      faceItem.entityId = entities[randomEntityIndex].id;
+      faceItem.libraryId = entities[randomEntityIndex].libraryId;
+      faceItem.confidence = Math.round(Math.random() * 1000) / 1000;
     }
-  },
-  {
-    id: '1945a3ba-f0a3-411e-8419-78e31c73150a',
-    name: 'Ringo Starr',
-    libraryId: 'f1297e1c-9c20-48fa-a8fd-46f1e6d62c43',
-    library: {
-      id: 'f1297e1c-9c20-48fa-a8fd-46f1e6d62c43',
-      name: 'Beatles'
-    },
-    profileImageUrl: null,
-    jsondata: {}
-  },
-  {
-    id: '8e35f28c-34aa-4ee3-8690-f62bf1a704fa',
-    name: 'George Harrison',
-    libraryId: 'f1297e1c-9c20-48fa-a8fd-46f1e6d62c43',
-    library: {
-      id: 'f1297e1c-9c20-48fa-a8fd-46f1e6d62c43',
-      name: 'Beatles'
-    },
-    profileImageUrl:
-      'http://www.slate.com/content/dam/slate/articles/arts/musicbox/2011/10/111004_MUSIC_harrisonFW.jpg.CROP.article250-medium.jpg',
-    jsondata: {
-      description: ''
-    }
-  },
-  {
-    id: '13595602-3a7f-48d3-bfde-2d029af479f6',
-    name: 'Gomez Addams',
-    libraryId: 'b64ef50a-0a5b-47ff-a403-a9a30f9241a4',
-    library: {
-      id: 'b64ef50a-0a5b-47ff-a403-a9a30f9241a4',
-      name: 'Addams Family'
-    },
-    profileImage: null,
-    jsondata: {}
-  },
-  {
-    id: 'c1666e9f-9dc0-40f9-aece-0ec1bfeae29a',
-    name: 'James Williams',
-    libraryId: 'b64ef50a-0a5b-47ff-a403-a9a30f9241a4',
-    library: {
-      id: 'b64ef50a-0a5b-47ff-a403-a9a30f9241a4',
-      name: 'Addams Family'
-    },
-    profileImage: null,
-    jsondata: {}
+    series.push({
+      startTimeMs: entryStartTime,
+      stopTimeMs: entryStartTime + Math.floor(Math.random() * 5000),
+      guid: guid(),
+      object: { ...faceItem, type: 'face'}
+    });
   }
-];
 
-const libraries = [
-  {
-    id: 'f1297e1c-9c20-48fa-a8fd-46f1e6d62c43',
-    name: 'Beatles'
-  },
-  {
-    id: 'b64ef50a-0a5b-47ff-a403-a9a30f9241a4',
-    name: 'Addams Family'
-  }
-];
+  return [
+    {
+      startTimeMs: startTime,
+      stopTimeMs: stopTime,
+      status: 'success',
+      series: series
+    }
+  ];
+}

--- a/packages/veritone-react-common/src/components/FaceEngineOutput/styles.scss
+++ b/packages/veritone-react-common/src/components/FaceEngineOutput/styles.scss
@@ -88,6 +88,11 @@
 
   &:hover {
     cursor: pointer;
+    background-color: $grey-2 !important;
+  }
+
+  &:active {
+    box-shadow: none !important;
   }
 }
 

--- a/packages/veritone-react-common/src/components/FingerprintEngineOutput/FingerprintEntity/EntityMetadata/index.js
+++ b/packages/veritone-react-common/src/components/FingerprintEngineOutput/FingerprintEntity/EntityMetadata/index.js
@@ -15,7 +15,7 @@ export default class EntityMetadata extends Component {
 
     return (
       <div className={classNames(styles.fingerprintEntityMetadata, className)}>
-        {jsondata && 
+        {jsondata &&
           Object.keys(jsondata).map(propName => {
             const propVal = jsondata[propName];
             return (

--- a/packages/veritone-react-common/src/components/FingerprintEngineOutput/FingerprintEntity/index.js
+++ b/packages/veritone-react-common/src/components/FingerprintEngineOutput/FingerprintEntity/index.js
@@ -55,7 +55,12 @@ export default class FingerprintEntity extends Component {
     return (
       <div className={classNames(styles.entityInfo)}>
         <div className={classNames(styles.logo)}>
-          <img src={entity.profileImageUrl || '//static.veritone.com/veritone-ui/default-nullstate.svg'} />
+          <img
+            src={
+              entity.profileImageUrl ||
+              '//static.veritone.com/veritone-ui/default-nullstate.svg'
+            }
+          />
         </div>
         <div>
           <div className={classNames(styles.entityName)}>

--- a/packages/veritone-react-common/src/components/FingerprintEngineOutput/FingerprintLibraries/FingerprintLibrary/index.js
+++ b/packages/veritone-react-common/src/components/FingerprintEngineOutput/FingerprintLibraries/FingerprintLibrary/index.js
@@ -79,9 +79,7 @@ export default class FingerprintLibrary extends Component {
             data={entityData}
             onClick={onClick}
             highlight={active}
-            key={`finger-print-entity-${entityData.id}-${
-              entityData.name
-            }`}
+            key={`finger-print-entity-${entityData.id}-${entityData.name}`}
           />
         );
       });

--- a/packages/veritone-react-common/src/components/FingerprintEngineOutput/index.js
+++ b/packages/veritone-react-common/src/components/FingerprintEngineOutput/index.js
@@ -92,7 +92,9 @@ export default class FingerprintEngineOutput extends Component {
     const { data, entities } = this.props;
 
     const entitiesMap = keyBy(cloneDeep(entities), 'id'); // deep copy entities to avoid changing original
-    const libraries = entities.filter(entity => entity.library && entity.library.id).map(entity => entity.library);
+    const libraries = entities
+      .filter(entity => entity.library && entity.library.id)
+      .map(entity => entity.library);
     const librariesMap = keyBy(libraries, 'id');
 
     sortBy(data, 'startTimeMs', 'endTimeMs');

--- a/packages/veritone-react-common/src/components/FingerprintEngineOutput/index.test.js
+++ b/packages/veritone-react-common/src/components/FingerprintEngineOutput/index.test.js
@@ -141,9 +141,7 @@ describe('Fingerprint Engine Output', () => {
 });
 
 describe('Fingerprint Content', () => {
-  let fingerprintContent = mount(
-    <FingerprintContent />
-  );
+  let fingerprintContent = mount(<FingerprintContent />);
 
   it('Invalid Library View', () => {
     expect(fingerprintContent.find('FingerprintEntity')).toHaveLength(0);
@@ -151,9 +149,12 @@ describe('Fingerprint Content', () => {
   });
 
   it('Invalid Entity View', () => {
-    const testEntity = Object.assign({
-      matches: [sampleData[0].series[0]]
-    }, sampleEntities[0]);
+    const testEntity = Object.assign(
+      {
+        matches: [sampleData[0].series[0]]
+      },
+      sampleEntities[0]
+    );
     const entityMode = fingerprintContent.setState({
       showLibrary: false,
       selectedEntity: testEntity
@@ -166,13 +167,14 @@ describe('Fingerprint Content', () => {
 });
 
 describe('Fingerprint Entity', () => {
-  const testEntity = Object.assign({
-    matches: [sampleData[0].series[0], sampleData[0].series[2]]
-  }, sampleEntities[0]);
-
-  let fingerprintEntity = mount(
-    <FingerprintEntity entity={testEntity} />
+  const testEntity = Object.assign(
+    {
+      matches: [sampleData[0].series[0], sampleData[0].series[2]]
+    },
+    sampleEntities[0]
   );
+
+  let fingerprintEntity = mount(<FingerprintEntity entity={testEntity} />);
 
   it('Invalid Stream Data', () => {
     expect(fingerprintEntity.find('EntityMetadata')).toHaveLength(0);

--- a/packages/veritone-react-common/src/components/Image/index.test.js
+++ b/packages/veritone-react-common/src/components/Image/index.test.js
@@ -4,13 +4,16 @@ import { mount } from 'enzyme';
 import Image from './';
 
 describe('Image', () => {
-  const TEST_IMG = 'https://pp.userapi.com/c624631/v624631866/38602/miSZV1RlzEY.jpg';
-  
+  const TEST_IMG =
+    'https://pp.userapi.com/c624631/v624631866/38602/miSZV1RlzEY.jpg';
+
   it('Image should be rendered in a div tag.', () => {
     const wrapper = mount(<Image src={TEST_IMG} />);
     expect(wrapper.find('div')).toHaveLength(1);
     expect(wrapper.props().src).toBe(TEST_IMG);
-    expect(wrapper.children().props().style.backgroundImage).toBe(`url(${TEST_IMG})`);
+    expect(wrapper.children().props().style.backgroundImage).toBe(
+      `url(${TEST_IMG})`
+    );
   });
 
   it('Image Height/Width should have default values if undefined.', () => {
@@ -20,8 +23,11 @@ describe('Image', () => {
   });
 
   it('Image Height/Width can be set to custom sizes.', () => {
-    const HEIGHT = '123px', WIDTH = '321px';
-    const wrapper = mount(<Image src={TEST_IMG} height={HEIGHT} width={WIDTH} />);
+    const HEIGHT = '123px',
+      WIDTH = '321px';
+    const wrapper = mount(
+      <Image src={TEST_IMG} height={HEIGHT} width={WIDTH} />
+    );
     expect(wrapper.children().props().style.height).toBe(HEIGHT);
     expect(wrapper.children().props().style.width).toBe(WIDTH);
   });
@@ -29,5 +35,5 @@ describe('Image', () => {
   it('Image Border can be enabled', () => {
     const wrapper = mount(<Image src={TEST_IMG} border />);
     expect(wrapper.children().props().style.border).toBe('1px solid #E4E4E4');
-  })
+  });
 });

--- a/packages/veritone-react-common/src/components/IngestionAdapters/DynamicAdapter/index.js
+++ b/packages/veritone-react-common/src/components/IngestionAdapters/DynamicAdapter/index.js
@@ -142,7 +142,7 @@ class DynamicAdapter extends React.Component {
 }
 
 function DynamicFieldForm({ fields = [], configuration, handleFieldChange }) {
-  return (fields)
+  return fields
     .map(field => {
       const inputId = field.name + 'DynamicField';
       const camelCasedFieldName = startCase(toLower(field.name));
@@ -224,9 +224,12 @@ export default {
       setName: true
     }
   },
-  validate: adapterStep => (configuration) => {
+  validate: adapterStep => configuration => {
     let errors = [];
-    if (get(adapterStep, 'supportedSourceTypes.length') && !configuration.sourceId) {
+    if (
+      get(adapterStep, 'supportedSourceTypes.length') &&
+      !configuration.sourceId
+    ) {
       errors.push('Source is required');
     }
     if (isArray(adapterStep.fields)) {

--- a/packages/veritone-react-common/src/components/IngestionAdapters/DynamicAdapter/index.test.js
+++ b/packages/veritone-react-common/src/components/IngestionAdapters/DynamicAdapter/index.test.js
@@ -13,22 +13,25 @@ describe('DynamicAdapter', () => {
     supportedSourceTypes: null,
     namespace: 'configuration'
   };
-  const SOURCES = [{
-    id: 'test-source-id-0'
-  }, {
-    id: 'test-source-id-1'
-  }]
+  const SOURCES = [
+    {
+      id: 'test-source-id-0'
+    },
+    {
+      id: 'test-source-id-1'
+    }
+  ];
   const SUPPORTED_SOURCE_TYPES = ['10'];
   const FIELDS = [
     {
-      "name": "location",
-      "options": null,
-      "type": "Text",
-      "max": null,
-      "min": null,
-      "step": null,
-      "info": "location",
-      "defaultValue": "Los Angeles"
+      name: 'location',
+      options: null,
+      type: 'Text',
+      max: null,
+      min: null,
+      step: null,
+      info: 'location',
+      defaultValue: 'Los Angeles'
     }
   ];
 
@@ -46,7 +49,7 @@ describe('DynamicAdapter', () => {
       validateCB: jest.fn()
     };
     jest.spyOn(testFuncs, 'validateCB');
-    testFuncs.validate({}).then((result) => {
+    testFuncs.validate({}).then(result => {
       testFuncs.validateCB(result);
       expect(testFuncs.validateCB).toHaveBeenCalled();
       done();
@@ -55,7 +58,9 @@ describe('DynamicAdapter', () => {
   });
 
   it('Validate function should only require sourceId if adapterConfig has supportedSourceTypes defined w/ length > 1', done => {
-    const ADAPTER_CONFIG = Object.assign({}, BASE_ADAPTER_CONFIG, { supportedSourceTypes: SUPPORTED_SOURCE_TYPES });
+    const ADAPTER_CONFIG = Object.assign({}, BASE_ADAPTER_CONFIG, {
+      supportedSourceTypes: SUPPORTED_SOURCE_TYPES
+    });
     const testFuncs = {
       validate: DynamicAdapterConfig.validate(ADAPTER_CONFIG),
       validateCB: jest.fn()
@@ -69,7 +74,9 @@ describe('DynamicAdapter', () => {
   });
 
   it('Validate function should only require fields which have default values', done => {
-    const ADAPTER_CONFIG = Object.assign({}, BASE_ADAPTER_CONFIG, { fields: FIELDS });
+    const ADAPTER_CONFIG = Object.assign({}, BASE_ADAPTER_CONFIG, {
+      fields: FIELDS
+    });
     const testFuncs = {
       validate: DynamicAdapterConfig.validate(ADAPTER_CONFIG),
       validateCB: jest.fn()
@@ -77,16 +84,18 @@ describe('DynamicAdapter', () => {
     jest.spyOn(testFuncs, 'validateCB');
     testFuncs.validate({}).catch(err => {
       testFuncs.validateCB(err);
-      expect(testFuncs.validateCB).toHaveBeenCalledWith(`${startCase(toLower(FIELDS[0].name))} is invalid`);
+      expect(testFuncs.validateCB).toHaveBeenCalledWith(
+        `${startCase(toLower(FIELDS[0].name))} is invalid`
+      );
 
       testSuccess();
     });
-    
-    function testSuccess () {
+
+    function testSuccess() {
       let configuration = {};
-      configuration[FIELDS[0].name] = 'test'
+      configuration[FIELDS[0].name] = 'test';
       testFuncs.validate(configuration).then(result => {
-        testFuncs.validateCB(result)
+        testFuncs.validateCB(result);
         expect(testFuncs.validateCB).toHaveBeenCalledWith(configuration);
         done();
         return result;
@@ -95,7 +104,9 @@ describe('DynamicAdapter', () => {
   });
 
   it('DynamicAdapter should automatically get the first page of sources', done => {
-    const ADAPTER_CONFIG = Object.assign({}, BASE_ADAPTER_CONFIG, { supportedSourceTypes: SUPPORTED_SOURCE_TYPES });
+    const ADAPTER_CONFIG = Object.assign({}, BASE_ADAPTER_CONFIG, {
+      supportedSourceTypes: SUPPORTED_SOURCE_TYPES
+    });
     const CONFIGURATION = {};
     const DynamicAdapter = DynamicAdapterConfig.adapter;
     const UPDATE_CONFIGURATION = jest.fn();
@@ -116,13 +127,19 @@ describe('DynamicAdapter', () => {
         supportedSourceTypes={SUPPORTED_SOURCE_TYPES}
         openCreateSource={OPEN_CREATE_SOURCE}
         closeCreateSource={CLOSE_CREATE_SOURCE}
-        loadNextPage={testFuncs.loadNextPage} />
-      );
-    expect(testFuncs.loadNextPage).toHaveBeenCalledWith({ startIndex: 0, stopIndex: 30});
+        loadNextPage={testFuncs.loadNextPage}
+      />
+    );
+    expect(testFuncs.loadNextPage).toHaveBeenCalledWith({
+      startIndex: 0,
+      stopIndex: 30
+    });
   });
 
   it('DynamicAdapter should set default values for any adapter input fields', () => {
-    const ADAPTER_CONFIG = Object.assign({}, BASE_ADAPTER_CONFIG, { fields: FIELDS });
+    const ADAPTER_CONFIG = Object.assign({}, BASE_ADAPTER_CONFIG, {
+      fields: FIELDS
+    });
     const CONFIGURATION = {};
     const DynamicAdapter = DynamicAdapterConfig.adapter;
     const UPDATE_CONFIGURATION = jest.fn();
@@ -141,16 +158,20 @@ describe('DynamicAdapter', () => {
         updateConfiguration={UPDATE_CONFIGURATION}
         openCreateSource={OPEN_CREATE_SOURCE}
         closeCreateSource={CLOSE_CREATE_SOURCE}
-        loadNextPage={testFuncs.loadNextPage} />
-      );
+        loadNextPage={testFuncs.loadNextPage}
+      />
+    );
     let expectedConfiguration = {};
     expectedConfiguration[FIELDS[0].name] = FIELDS[0].defaultValue;
     expect(UPDATE_CONFIGURATION).toHaveBeenCalledWith(expectedConfiguration);
   });
 
   it('DynamicAdapter should rehydrate its state if the existing configuration matches the adapters fields', () => {
-    const ADAPTER_CONFIG = Object.assign({}, BASE_ADAPTER_CONFIG, { supportedSourceTypes: SUPPORTED_SOURCE_TYPES, fields: FIELDS });
-    const TEST_FIELD_VALUE  = 'TEST FIELD VALUE';
+    const ADAPTER_CONFIG = Object.assign({}, BASE_ADAPTER_CONFIG, {
+      supportedSourceTypes: SUPPORTED_SOURCE_TYPES,
+      fields: FIELDS
+    });
+    const TEST_FIELD_VALUE = 'TEST FIELD VALUE';
     let configuration = {};
     configuration[FIELDS[0].name] = TEST_FIELD_VALUE;
     const DynamicAdapter = DynamicAdapterConfig.adapter;
@@ -171,11 +192,11 @@ describe('DynamicAdapter', () => {
         supportedSourceTypes={SUPPORTED_SOURCE_TYPES}
         openCreateSource={OPEN_CREATE_SOURCE}
         closeCreateSource={CLOSE_CREATE_SOURCE}
-        loadNextPage={testFuncs.loadNextPage} />
-      );
+        loadNextPage={testFuncs.loadNextPage}
+      />
+    );
     let expectedConfiguration = {};
     expectedConfiguration[FIELDS[0].name] = TEST_FIELD_VALUE;
     expect(UPDATE_CONFIGURATION).toHaveBeenCalledWith(expectedConfiguration);
   });
-
 });

--- a/packages/veritone-react-common/src/components/IngestionAdapters/DynamicAdapter/story.js
+++ b/packages/veritone-react-common/src/components/IngestionAdapters/DynamicAdapter/story.js
@@ -329,12 +329,14 @@ function closeCreateSource() {
   console.log('closeCreateSource');
 }
 
-function loadNextPage({startIndex, stopIndex}) {
+function loadNextPage({ startIndex, stopIndex }) {
   console.log('Called loadNextPage');
   console.log(startIndex + ' ' + stopIndex);
-  return new Promise(resolve => setTimeout(() => {
-    resolve(cloneDeep(SOURCES));
-  }, 2000));
+  return new Promise(resolve =>
+    setTimeout(() => {
+      resolve(cloneDeep(SOURCES));
+    }, 2000)
+  );
 }
 
 let configuration = {

--- a/packages/veritone-react-common/src/components/LogoDetectionEngineOutput/index.js
+++ b/packages/veritone-react-common/src/components/LogoDetectionEngineOutput/index.js
@@ -115,10 +115,18 @@ export default class LogoDetectionEngineOutput extends Component {
             const stopTime = Math.ceil(itemInfo.stopTimeMs / 1000) * 1000;
             const startTimeString = msToReadableString(itemInfo.startTimeMs);
             const stopTimeString = msToReadableString(itemInfo.stopTimeMs);
-            const timeRangeKeyPart = `${itemInfo.startTimeMs}-${itemInfo.stopTimeMs}`;
+            const timeRangeKeyPart = `${itemInfo.startTimeMs}-${
+              itemInfo.stopTimeMs
+            }`;
             const boundingPoly = get(itemInfo.object, 'boundingPoly', []);
-            const boundingPolyKeyPart = boundingPoly.length ? `x1-${boundingPoly[0].x}-y1-${boundingPoly[0].y}` : '';
-            const pillKey = `logo-pill-${kebabCase(itemInfo.object.label)}-${timeRangeKeyPart}-${itemInfo.confidence}-${boundingPolyKeyPart}`;
+            const boundingPolyKeyPart = boundingPoly.length
+              ? `x1-${boundingPoly[0].x}-y1-${boundingPoly[0].y}`
+              : '';
+            const pillKey = `logo-pill-${kebabCase(
+              itemInfo.object.label
+            )}-${timeRangeKeyPart}-${
+              itemInfo.confidence
+            }-${boundingPolyKeyPart}`;
             const logoItem = (
               <PillButton
                 value={index}

--- a/packages/veritone-react-common/src/components/MediaInfoPanel/index.js
+++ b/packages/veritone-react-common/src/components/MediaInfoPanel/index.js
@@ -183,7 +183,12 @@ class MediaInfoPanel extends Component {
   };
 
   render() {
-    const { isOpen, isMenuOpen, isEditMetadataOpen, isEditTagsOpen } = this.state;
+    const {
+      isOpen,
+      isMenuOpen,
+      isEditMetadataOpen,
+      isEditTagsOpen
+    } = this.state;
 
     const { tdo } = this.props;
 

--- a/packages/veritone-react-common/src/components/MediaInfoPanel/index.test.js
+++ b/packages/veritone-react-common/src/components/MediaInfoPanel/index.test.js
@@ -202,8 +202,17 @@ describe('MediaInfoPanel', () => {
       '//static.veritone.com/veritone-ui/program_image_null.svg'
     );
 
-    expect(wrapper.find('.infoPanelHeader').find('[aria-label="Edit"]').exists()).toEqual(true);
-    wrapper.find('.infoPanelHeader').find('[aria-label="Edit"]').first().simulate('click');
+    expect(
+      wrapper
+        .find('.infoPanelHeader')
+        .find('[aria-label="Edit"]')
+        .exists()
+    ).toEqual(true);
+    wrapper
+      .find('.infoPanelHeader')
+      .find('[aria-label="Edit"]')
+      .first()
+      .simulate('click');
     expect(wrapper.find('#menu-list-grow').exists()).toEqual(true);
     const moreMenuItems = wrapper.find('#menu-list-grow').find('li');
     expect(moreMenuItems.length).toEqual(2);

--- a/packages/veritone-react-common/src/components/OCREngineOutputView/index.test.js
+++ b/packages/veritone-react-common/src/components/OCREngineOutputView/index.test.js
@@ -55,13 +55,17 @@ describe('OCREngineOutputView', () => {
   });
 
   it('adds props.className to the root', function() {
-    const wrapper = mount(<OCREngineOutputView data={ocrAssets} className="ocr-class"/>);
+    const wrapper = mount(
+      <OCREngineOutputView data={ocrAssets} className="ocr-class" />
+    );
     expect(wrapper.hasClass('ocr-class')).toBe(true);
   });
 
   it('calls props.onOcrClicked when user clicks an orc pill', () => {
     const handler = jest.fn();
-    const wrapper = mount(<OCREngineOutputView data={ocrAssets} onOcrClicked={handler} />);
+    const wrapper = mount(
+      <OCREngineOutputView data={ocrAssets} onOcrClicked={handler} />
+    );
     wrapper
       .find('.ocrContainer')
       .first()

--- a/packages/veritone-react-common/src/components/ObjectDetectionEngineOutput/ObjectGroup/index.js
+++ b/packages/veritone-react-common/src/components/ObjectDetectionEngineOutput/ObjectGroup/index.js
@@ -17,10 +17,18 @@ const ObjectGroup = ({
     <span>
       {objectGroup.series &&
         objectGroup.series.map(objectData => {
-          const timeRangeKeyPart = `${objectData.startTimeMs}-${objectData.stopTimeMs}`;
+          const timeRangeKeyPart = `${objectData.startTimeMs}-${
+            objectData.stopTimeMs
+          }`;
           const boundingPoly = get(objectData.object, 'boundingPoly', []);
-          const boundingPolyKeyPart = boundingPoly.length ? `x1-${boundingPoly[0].x}-y1-${boundingPoly[0].y}` : '';
-          const pillKey = `object-pill-${kebabCase(objectData.object.label)}-${timeRangeKeyPart}-${objectData.object.confidence}-${boundingPolyKeyPart}`;
+          const boundingPolyKeyPart = boundingPoly.length
+            ? `x1-${boundingPoly[0].x}-y1-${boundingPoly[0].y}`
+            : '';
+          const pillKey = `object-pill-${kebabCase(
+            objectData.object.label
+          )}-${timeRangeKeyPart}-${
+            objectData.object.confidence
+          }-${boundingPolyKeyPart}`;
           return (
             <PillButton
               key={pillKey}

--- a/packages/veritone-react-common/src/components/SourceManagement/ContentTemplates/TemplateForms/index.js
+++ b/packages/veritone-react-common/src/components/SourceManagement/ContentTemplates/TemplateForms/index.js
@@ -230,7 +230,11 @@ function BuildFormElements({
         <span>{title}</span>
         {element}
         <div className={styles.arrayAdd}>
-          <IconButton className={styles.noHover} disableRipple onClick={handleArrayElementAdd(schemaId, schemaProp)}>
+          <IconButton
+            className={styles.noHover}
+            disableRipple
+            onClick={handleArrayElementAdd(schemaId, schemaProp)}
+          >
             <AddIcon />
           </IconButton>
         </div>

--- a/packages/veritone-react-common/src/components/SourceManagement/SourceDropdownMenu/index.js
+++ b/packages/veritone-react-common/src/components/SourceManagement/SourceDropdownMenu/index.js
@@ -30,27 +30,29 @@ export default class SourceDropdownMenu extends React.Component {
     hasNextPage: false,
     isNextPageLoading: false,
     sources: []
-  }
+  };
 
   UNSAFE_componentWillMount() {
     this.loadMoreRows({ startIndex: 0, stopIndex: 30 });
   }
 
-  loadMoreRows = ({startIndex, stopIndex}) => {
+  loadMoreRows = ({ startIndex, stopIndex }) => {
     this.setState({ isNextPageLoading: true });
-    return this.props.loadNextPage({startIndex, stopIndex}).then(sourcePage => {
-      const newState = {
-        hasNextPage: !!get(sourcePage, 'length'),
-        isNextPageLoading: false,
-        sources: cloneDeep(this.state.sources).concat(sourcePage)
-      }
-      if (newState.sources.length && !this.props.sourceId) {
-        this.props.handleSourceChange(newState.sources[0].id);
-      }
-      this.setState(newState);
-      return sourcePage;
-    });
-  }
+    return this.props
+      .loadNextPage({ startIndex, stopIndex })
+      .then(sourcePage => {
+        const newState = {
+          hasNextPage: !!get(sourcePage, 'length'),
+          isNextPageLoading: false,
+          sources: cloneDeep(this.state.sources).concat(sourcePage)
+        };
+        if (newState.sources.length && !this.props.sourceId) {
+          this.props.handleSourceChange(newState.sources[0].id);
+        }
+        this.setState(newState);
+        return sourcePage;
+      });
+  };
 
   render() {
     return (
@@ -130,22 +132,19 @@ class SourceContainer extends React.Component {
     }
 
     const version =
-    source.sourceType && source.sourceType.sourceSchema
-      ? source.sourceType.sourceSchema.majorVersion +
-        '.' +
-        source.sourceType.sourceSchema.minorVersion
-      : undefined;
+      source.sourceType && source.sourceType.sourceSchema
+        ? source.sourceType.sourceSchema.majorVersion +
+          '.' +
+          source.sourceType.sourceSchema.minorVersion
+        : undefined;
 
     const handleItemClick = source => () => {
       this.props.handleSourceChange(source.id);
       this.handleMenuClose();
-    }
+    };
 
     return (
-      <div
-        key={key}
-        style={style}
-      >
+      <div key={key} style={style}>
         <MenuItem
           key={source.id}
           value={source.id}

--- a/packages/veritone-react-common/src/components/SourceManagement/SourceDropdownMenu/styles.scss
+++ b/packages/veritone-react-common/src/components/SourceManagement/SourceDropdownMenu/styles.scss
@@ -38,7 +38,7 @@
   &:focus {
     outline: none;
   }
-  
+
   & > li {
     color: rgba(0, 0, 0, 0.87) !important;
     font-size: 16px !important;

--- a/packages/veritone-react-common/src/components/StatusPill/index.test.js
+++ b/packages/veritone-react-common/src/components/StatusPill/index.test.js
@@ -4,49 +4,76 @@ import StatusPill from './';
 
 describe('StatusPill', () => {
   it('Should render props.status', () => {
-    let wrapper = mount(<StatusPill status='active' />);
+    let wrapper = mount(<StatusPill status="active" />);
     expect(wrapper.text()).toMatch(/active/);
     let span = wrapper.find('span');
     expect(span).toHaveLength(1);
     expect(span.get(0).props.children).toEqual('active');
 
-    wrapper = mount(<StatusPill status='inactive' />);
+    wrapper = mount(<StatusPill status="inactive" />);
     expect(wrapper.text()).toMatch(/inactive/);
     span = wrapper.find('span');
     expect(span.get(0).props.children).toEqual('inactive');
 
-    wrapper = mount(<StatusPill status='paused' />);
+    wrapper = mount(<StatusPill status="paused" />);
     expect(wrapper.text()).toMatch(/paused/);
     span = wrapper.find('span');
     expect(span.get(0).props.children).toEqual('paused');
 
-    wrapper = mount(<StatusPill status='processing' />);
+    wrapper = mount(<StatusPill status="processing" />);
     expect(wrapper.text()).toMatch(/processing/);
     span = wrapper.find('span');
     expect(span.get(0).props.children).toEqual('processing');
   });
 
   it('Should render correct styles', () => {
-    let wrapper = mount(<StatusPill status='active' />);
+    let wrapper = mount(<StatusPill status="active" />);
     expect(wrapper.find('div').get(0).props.className).toEqual('statusPill');
-    expect(wrapper.find('div').get(0).props.style).toHaveProperty('backgroundColor', '#00C853');
-    expect(wrapper.find('div').get(0).props.style).toHaveProperty('color', '#FFFFFF');
+    expect(wrapper.find('div').get(0).props.style).toHaveProperty(
+      'backgroundColor',
+      '#00C853'
+    );
+    expect(wrapper.find('div').get(0).props.style).toHaveProperty(
+      'color',
+      '#FFFFFF'
+    );
 
     const span = wrapper.find('span');
     expect(span).toHaveLength(1);
     expect(span.get(0).props.className).toEqual('statusPillText');
 
-    wrapper = mount(<StatusPill status='inactive' />);
-    expect(wrapper.find('div').get(0).props.style).toHaveProperty('backgroundColor', '#9E9E9E');
-    expect(wrapper.find('div').get(0).props.style).toHaveProperty('color', '#FFFFFF');
+    wrapper = mount(<StatusPill status="inactive" />);
+    expect(wrapper.find('div').get(0).props.style).toHaveProperty(
+      'backgroundColor',
+      '#9E9E9E'
+    );
+    expect(wrapper.find('div').get(0).props.style).toHaveProperty(
+      'color',
+      '#FFFFFF'
+    );
 
-    wrapper = mount(<StatusPill status='paused' />);
-    expect(wrapper.find('div').get(0).props.style).toHaveProperty('backgroundColor', '#FFFFFF');
-    expect(wrapper.find('div').get(0).props.style).toHaveProperty('color', '#607D8B');
-    expect(wrapper.find('div').get(0).props.style).toHaveProperty('border', '1px solid #607D8B');
+    wrapper = mount(<StatusPill status="paused" />);
+    expect(wrapper.find('div').get(0).props.style).toHaveProperty(
+      'backgroundColor',
+      '#FFFFFF'
+    );
+    expect(wrapper.find('div').get(0).props.style).toHaveProperty(
+      'color',
+      '#607D8B'
+    );
+    expect(wrapper.find('div').get(0).props.style).toHaveProperty(
+      'border',
+      '1px solid #607D8B'
+    );
 
-    wrapper = mount(<StatusPill status='processing' />);
-    expect(wrapper.find('div').get(0).props.style).toHaveProperty('backgroundColor', '#2196F3');
-    expect(wrapper.find('div').get(0).props.style).toHaveProperty('color', '#FFFFFF');
+    wrapper = mount(<StatusPill status="processing" />);
+    expect(wrapper.find('div').get(0).props.style).toHaveProperty(
+      'backgroundColor',
+      '#2196F3'
+    );
+    expect(wrapper.find('div').get(0).props.style).toHaveProperty(
+      'color',
+      '#FFFFFF'
+    );
   });
 });

--- a/packages/veritone-react-common/src/components/StructuredDataEngineOutput/index.test.js
+++ b/packages/veritone-react-common/src/components/StructuredDataEngineOutput/index.test.js
@@ -106,34 +106,42 @@ const SCHEMA_BY_ID = {
 };
 
 const ENGINES = [
-  {id: 'time-correlated-weather', name: 'Weather'},
-  {id: 'time-correlated-fb-feed', name: 'Facebook feeds'}];
+  { id: 'time-correlated-weather', name: 'Weather' },
+  { id: 'time-correlated-fb-feed', name: 'Facebook feeds' }
+];
 
 describe('StructuredDataEngineOutput', () => {
   it('should show structured data array results', () => {
-    const structuredData = [{
-      sourceEngineId: ENGINES[0].id,
-      sourceEngineName: ENGINES[0].name,
-      series: [{
-        startTimeMs: 0,
-        stopTimeMs: 300000,
-        structuredData: {
-          '8a8bbd66-d160-480e-b3fb-7a935ac4e8dd': [{
-            geoLocation: '34.05, -118.24',
-            temperature: 69.71,
-            pressure: 1015,
-            humidity: 56,
-            temperatureMin: 62.6,
-            temperatureMax: 77,
-            visibility: 16093,
-            windSpeed: 3.36,
-            windDegree: 0,
-            datetimeStart: '2018-02-21T21:30:00.000Z',
-            datetimeEnd: '2018-02-21T22:30:00.000Z',
-            locationName: 'Los Angeles'
-          }]
-        }
-      }]}];
+    const structuredData = [
+      {
+        sourceEngineId: ENGINES[0].id,
+        sourceEngineName: ENGINES[0].name,
+        series: [
+          {
+            startTimeMs: 0,
+            stopTimeMs: 300000,
+            structuredData: {
+              '8a8bbd66-d160-480e-b3fb-7a935ac4e8dd': [
+                {
+                  geoLocation: '34.05, -118.24',
+                  temperature: 69.71,
+                  pressure: 1015,
+                  humidity: 56,
+                  temperatureMin: 62.6,
+                  temperatureMax: 77,
+                  visibility: 16093,
+                  windSpeed: 3.36,
+                  windDegree: 0,
+                  datetimeStart: '2018-02-21T21:30:00.000Z',
+                  datetimeEnd: '2018-02-21T22:30:00.000Z',
+                  locationName: 'Los Angeles'
+                }
+              ]
+            }
+          }
+        ]
+      }
+    ];
 
     const onEngineChange = jest.fn();
     const onExpandClick = jest.fn();
@@ -146,34 +154,47 @@ describe('StructuredDataEngineOutput', () => {
         selectedEngineId={ENGINES[0].id}
         onEngineChange={onEngineChange}
         onExpandClick={onExpandClick}
-    />);
+      />
+    );
 
     expect(wrapper.find('.headerTitle').text()).toEqual('Structured Data');
     expect(wrapper.find('.schemaMenu').exists()).toEqual(true);
-    const engineSelector = wrapper.find('.headerActions').find('.engineSelect').first();
+    const engineSelector = wrapper
+      .find('.headerActions')
+      .find('.engineSelect')
+      .first();
     expect(engineSelector.find('input').prop('value')).toEqual(ENGINES[0].id);
     expect(wrapper.find('[aria-label="Expanded View"]').exists()).toEqual(true);
     expect(wrapper.find('table')).toHaveLength(1);
-    expect(wrapper.find('table').find('tbody').find('tr')).toHaveLength(1);
+    expect(
+      wrapper
+        .find('table')
+        .find('tbody')
+        .find('tr')
+    ).toHaveLength(1);
   });
 
   it('should show structured data object result', () => {
-    const structuredDataAsArray = [{
-      sourceEngineId: ENGINES[1].id,
-      sourceEngineName: ENGINES[1].name,
-      series: [{
-        startTimeMs: 0,
-        stopTimeMs: 300000,
-        structuredData: {
-          'c46e4675-73a0-44ce-adca-b6ebab897c21': {
-            id: 1234567,
-            about: 'about fb feed',
-            website: 'veritone.com',
-            fan_count: 987654321
+    const structuredDataAsArray = [
+      {
+        sourceEngineId: ENGINES[1].id,
+        sourceEngineName: ENGINES[1].name,
+        series: [
+          {
+            startTimeMs: 0,
+            stopTimeMs: 300000,
+            structuredData: {
+              'c46e4675-73a0-44ce-adca-b6ebab897c21': {
+                id: 1234567,
+                about: 'about fb feed',
+                website: 'veritone.com',
+                fan_count: 987654321
+              }
+            }
           }
-        }
-      }]
-    }];
+        ]
+      }
+    ];
 
     const onEngineChange = jest.fn();
     const onExpandClick = jest.fn();
@@ -186,59 +207,81 @@ describe('StructuredDataEngineOutput', () => {
         selectedEngineId={ENGINES[1].id}
         onEngineChange={onEngineChange}
         onExpandClick={onExpandClick}
-      />);
+      />
+    );
 
     expect(wrapper.find('.headerTitle').text()).toEqual('Structured Data');
     expect(wrapper.find('.schemaMenu').exists()).toEqual(true);
-    const engineSelector = wrapper.find('.headerActions').find('.engineSelect').first();
+    const engineSelector = wrapper
+      .find('.headerActions')
+      .find('.engineSelect')
+      .first();
     expect(engineSelector.find('input').prop('value')).toEqual(ENGINES[1].id);
     expect(wrapper.find('[aria-label="Expanded View"]').exists()).toEqual(true);
     expect(wrapper.find('table')).toHaveLength(1);
-    expect(wrapper.find('table').find('tbody').find('tr')).toHaveLength(1);
+    expect(
+      wrapper
+        .find('table')
+        .find('tbody')
+        .find('tr')
+    ).toHaveLength(1);
   });
 
   it('should hide engine selection when no engines passed', () => {
-    const structuredDataAsObject = [{
-      series: [{
-        startTimeMs: 0,
-        stopTimeMs: 300000,
-        structuredData: {
-          'c46e4675-73a0-44ce-adca-b6ebab897c21': {
-            id: 1234567,
-            about: 'about fb feed',
-            website: 'veritone.com',
-            fan_count: 987654321
+    const structuredDataAsObject = [
+      {
+        series: [
+          {
+            startTimeMs: 0,
+            stopTimeMs: 300000,
+            structuredData: {
+              'c46e4675-73a0-44ce-adca-b6ebab897c21': {
+                id: 1234567,
+                about: 'about fb feed',
+                website: 'veritone.com',
+                fan_count: 987654321
+              }
+            }
           }
-        }
-      }]
-    }];
+        ]
+      }
+    ];
 
     const wrapper = mount(
       <StructuredDataEngineOutput
         data={structuredDataAsObject}
         schemasById={SCHEMA_BY_ID}
-      />);
+      />
+    );
 
     expect(wrapper.find('.headerTitle').text()).toEqual('Structured Data');
     expect(wrapper.find('.schemaMenu').exists()).toEqual(true);
     expect(wrapper.find('.engineSelect').exists()).toEqual(false);
     expect(wrapper.find('[ariaLabel="Expanded View"]').exists()).toEqual(false);
     expect(wrapper.find('table')).toHaveLength(1);
-    expect(wrapper.find('table').find('tbody').find('tr')).toHaveLength(1);
+    expect(
+      wrapper
+        .find('table')
+        .find('tbody')
+        .find('tr')
+    ).toHaveLength(1);
   });
 
   it('should show header and no data table when no data passed in', () => {
     const wrapper = mount(
-      <StructuredDataEngineOutput
-        data={[]}
-        schemasById={{}}
-      />);
+      <StructuredDataEngineOutput data={[]} schemasById={{}} />
+    );
 
     expect(wrapper.find('.headerTitle').text()).toEqual('Structured Data');
     expect(wrapper.find('.schemaMenu').exists()).toEqual(false);
     expect(wrapper.find('.engineSelect').exists()).toEqual(false);
     expect(wrapper.find('[ariaLabel="Expanded View"]').exists()).toEqual(false);
     expect(wrapper.find('table')).toHaveLength(0);
-    expect(wrapper.find('table').find('tbody').find('tr')).toHaveLength(0);
+    expect(
+      wrapper
+        .find('table')
+        .find('tbody')
+        .find('tr')
+    ).toHaveLength(0);
   });
 });

--- a/packages/veritone-react-common/src/components/TranscriptEngineOutput/TranscriptFragment/OverviewFragment/styles.scss
+++ b/packages/veritone-react-common/src/components/TranscriptEngineOutput/TranscriptFragment/OverviewFragment/styles.scss
@@ -13,7 +13,7 @@
   }
 
   &::after {
-    content: " ";
+    content: ' ';
   }
 }
 

--- a/packages/veritone-react-common/src/components/TranscriptEngineOutput/TranscriptFragment/SnippetFragment/styles.scss
+++ b/packages/veritone-react-common/src/components/TranscriptEngineOutput/TranscriptFragment/SnippetFragment/styles.scss
@@ -13,7 +13,7 @@
   }
 
   &::after {
-    content: " ";
+    content: ' ';
   }
 }
 

--- a/packages/veritone-react-common/src/components/TranslationEngineOutput/index.js
+++ b/packages/veritone-react-common/src/components/TranslationEngineOutput/index.js
@@ -118,13 +118,13 @@ export default class TranslationEngineOutput extends Component {
     translatedLanguagesInfo = sortBy(translatedLanguagesInfo, 'language');
 
     const selectedLanguage =
-        (state && state.selectedLanguage) ||
-        defaultLanguage ||
-        translatedLanguages[0];
+      (state && state.selectedLanguage) ||
+      defaultLanguage ||
+      translatedLanguages[0];
 
     return {
-      ...state, 
-      languages: translatedLanguagesInfo, 
+      ...state,
+      languages: translatedLanguagesInfo,
       selectedLanguage: selectedLanguage
     };
   }

--- a/packages/veritone-react-common/src/components/TranslationEngineOutput/index.test.js
+++ b/packages/veritone-react-common/src/components/TranslationEngineOutput/index.test.js
@@ -7,54 +7,72 @@ const sampleData = [
     startTimeMs: 0,
     stopTimeMs: 9000,
     status: 'success',
-    series: [{
-      language: 'en-US',
-      startTimeMs: 0,
-      stopTimeMs: 2000,
-      words: [{
-        confidence: 0.6,
-        word: 'tada'
-      }, {
-        confidence: 0.7,
-        word: 'todo'
-      }, {
-        confidence: 0.5,
-        word: 'teodeo'
-      }]
-    },{
-      language: 'en-US',
-      startTimeMs: 2000,
-      stopTimeMs: 5000,
-      words: [{
-        confidence: 0.6,
-        word: 'baba'
-      }, {
-        confidence: 0.7,
-        word: 'wawa'
-      }, {
-        confidence: 0.9,
-        word: 'wakanda'
-      }]
-    },{
-      language: 'en-US',
-      startTimeMs: 5000,
-      stopTimeMs: 6000
-    },{
-      language: 'en-US',
-      startTimeMs: 6000,
-      stopTimeMs: 9000,
-      words: [{
-        confidence: 0.5,
-        word: 'test'
-      }, {
-        confidence: 0.4,
-        word: 'best'
-      }, {
-        confidence: 0.2,
-        word: 'zet'
-      }]
-    }]
-  },{
+    series: [
+      {
+        language: 'en-US',
+        startTimeMs: 0,
+        stopTimeMs: 2000,
+        words: [
+          {
+            confidence: 0.6,
+            word: 'tada'
+          },
+          {
+            confidence: 0.7,
+            word: 'todo'
+          },
+          {
+            confidence: 0.5,
+            word: 'teodeo'
+          }
+        ]
+      },
+      {
+        language: 'en-US',
+        startTimeMs: 2000,
+        stopTimeMs: 5000,
+        words: [
+          {
+            confidence: 0.6,
+            word: 'baba'
+          },
+          {
+            confidence: 0.7,
+            word: 'wawa'
+          },
+          {
+            confidence: 0.9,
+            word: 'wakanda'
+          }
+        ]
+      },
+      {
+        language: 'en-US',
+        startTimeMs: 5000,
+        stopTimeMs: 6000
+      },
+      {
+        language: 'en-US',
+        startTimeMs: 6000,
+        stopTimeMs: 9000,
+        words: [
+          {
+            confidence: 0.5,
+            word: 'test'
+          },
+          {
+            confidence: 0.4,
+            word: 'best'
+          },
+          {
+            confidence: 0.2,
+            word: 'zet'
+          }
+        ]
+      }
+    ]
+  },
+  {
     startTimeMs: 9000,
     stopTimeMs: 15000,
     status: 'error'
@@ -94,7 +112,6 @@ describe('Translation Engine Output', () => {
     expect(dataSegments.at(0).find('span.highlight')).toHaveLength(1);
     expect(dataSegments.at(1).find('span.highlight')).toHaveLength(0);
     expect(dataSegments.at(2).find('span.highlight')).toHaveLength(0);
-   
   });
 
   it('invalid no translation data segment', () => {

--- a/packages/veritone-react-common/src/components/share-components/AlertDialog/index.js
+++ b/packages/veritone-react-common/src/components/share-components/AlertDialog/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { any, bool, string, func, oneOfType} from 'prop-types';
+import { any, bool, string, func, oneOfType } from 'prop-types';
 
 import { omit } from 'lodash';
 
@@ -21,14 +21,14 @@ export default class AlertDialog extends Component {
     open: bool,
     title: string,
     content: string,
-    fullScreen:bool,
+    fullScreen: bool,
     cancelButtonLabel: string,
     approveButtonLabel: string,
     onCancel: func,
     onApprove: func.isRequired,
     cancelValue: oneOfType([any]),
     approveValue: oneOfType([any])
-  }
+  };
 
   static defaultProps = {
     open: false,
@@ -39,19 +39,26 @@ export default class AlertDialog extends Component {
     approveValue: 'approve',
     cancelButtonLabel: 'Cancel',
     approveButtonLabel: 'Continue'
-  }
+  };
 
-  handleCancel = (event) => {
+  handleCancel = event => {
     this.props.onCancel(this.props.cancelValue);
-  }
+  };
 
-  handleApprove = (event) => {
+  handleApprove = event => {
     this.props.onApprove(this.props.approveValue);
-  }
+  };
 
-  render () {
-    const { open, title, content, onCancel, cancelButtonLabel, approveButtonLabel } = this.props;
-    const forwardingProps = {...this.props};
+  render() {
+    const {
+      open,
+      title,
+      content,
+      onCancel,
+      cancelButtonLabel,
+      approveButtonLabel
+    } = this.props;
+    const forwardingProps = { ...this.props };
     const omittedProps = [
       'onCancel',
       'onApprove',
@@ -68,27 +75,19 @@ export default class AlertDialog extends Component {
         aria-labelledby={labelId}
         aria-describedby={descriptionId}
       >
-        {
-          title &&
-          (<DialogTitle id={labelId}>{title}</DialogTitle>)
-        }
-        {
-          content && 
-          (<DialogContent>
-            <DialogContentText id={descriptionId}>
-              {content}
-            </DialogContentText>
-          </DialogContent>)
-        }
+        {title && <DialogTitle id={labelId}>{title}</DialogTitle>}
+        {content && (
+          <DialogContent>
+            <DialogContentText id={descriptionId}>{content}</DialogContentText>
+          </DialogContent>
+        )}
         <DialogActions>
-          {
-            onCancel && (
-              <Button onClick={this.handleCancel} color='primary'>
-                {cancelButtonLabel}
-              </Button>
-            )
-          }
-          <Button onClick={this.handleApprove} color='primary' autoFocus>
+          {onCancel && (
+            <Button onClick={this.handleCancel} color="primary">
+              {cancelButtonLabel}
+            </Button>
+          )}
+          <Button onClick={this.handleApprove} color="primary" autoFocus>
             {approveButtonLabel}
           </Button>
         </DialogActions>

--- a/packages/veritone-react-common/src/components/share-components/story.js
+++ b/packages/veritone-react-common/src/components/share-components/story.js
@@ -1,53 +1,57 @@
 import React, { Component } from 'react';
-import { storiesOf,  } from '@storybook/react';
+import { storiesOf } from '@storybook/react';
 import { boolean } from '@storybook/addon-knobs/react';
 import { action } from '@storybook/addon-actions';
 
 import styles from './styles.scss';
 import PillButton from './buttons/PillButton';
-import AlertDialog from './AlertDialog'
+import AlertDialog from './AlertDialog';
 import DynamicContentScroll from './scrolls/DynamicContentScroll';
 
 storiesOf('Share Components', module)
-.add('Pill Button', () => {
-  return (
-    <div className={styles.pillButtons}>
-      <PillButton label="default label" info="(2)" />
-      <PillButton
-        label="custom label"
-        info="custom info"
-        className={styles.customButton}
-        infoClassName={styles.customBadge}
-        labelClassName={styles.customLabel}
-      />
-      <PillButton label="label only" />
-      <PillButton info="(info only)" />
-      <PillButton
-        label="this is a very long label for a pill button"
-        info="(2)"
-      />
-      <PillButton label="highlighted button" info="(tada)" highlight />
-    </div>
-  );
-})
-.add('Alert Dialog', () => {
-  const title = `Don't read the description text!!!`;
-  const content = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, Ut enim ad minim veniam. By clicking either button you agree to grant us an option to claim your immortal soul. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`;
+  .add('Pill Button', () => {
+    return (
+      <div className={styles.pillButtons}>
+        <PillButton label="default label" info="(2)" />
+        <PillButton
+          label="custom label"
+          info="custom info"
+          className={styles.customButton}
+          infoClassName={styles.customBadge}
+          labelClassName={styles.customLabel}
+        />
+        <PillButton label="label only" />
+        <PillButton info="(info only)" />
+        <PillButton
+          label="this is a very long label for a pill button"
+          info="(2)"
+        />
+        <PillButton label="highlighted button" info="(tada)" highlight />
+      </div>
+    );
+  })
+  .add('Alert Dialog', () => {
+    const title = `Don't read the description text!!!`;
+    const content = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, Ut enim ad minim veniam. By clicking either button you agree to grant us an option to claim your immortal soul. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`;
 
-  return (
-    <AlertDialog
-      open={ boolean('open', true) }
-      title= { boolean('has title', true) ? title : null}
-      content={ boolean('has content', true) ? content : null}
-      fullScreen = { boolean('Full Screen', false)}
-      onApprove = { action('approve button clicked') }
-      onCancel = { boolean('Enable Cancel Callback', false) ? action('cancel button clicked') : null }
-    />
-  );
-})
-.add('Dynamic Vertical Scroll', () => {
-  return <DynamicScrollContainer />;
-});
+    return (
+      <AlertDialog
+        open={boolean('open', true)}
+        title={boolean('has title', true) ? title : null}
+        content={boolean('has content', true) ? content : null}
+        fullScreen={boolean('Full Screen', false)}
+        onApprove={action('approve button clicked')}
+        onCancel={
+          boolean('Enable Cancel Callback', false)
+            ? action('cancel button clicked')
+            : null
+        }
+      />
+    );
+  })
+  .add('Dynamic Vertical Scroll', () => {
+    return <DynamicScrollContainer />;
+  });
 
 // Dynamic Container Helpers
 class DynamicScrollContainer extends Component {

--- a/packages/veritone-redux-common/src/modules/confirmation/saga.test.js
+++ b/packages/veritone-redux-common/src/modules/confirmation/saga.test.js
@@ -56,7 +56,7 @@ describe('confirmation sagas', function() {
 
       next = gen.next();
       next = gen.next({ cancel: module.cancelConfirmAction('123') });
-      expect(next.value).toBe(undefined)
+      expect(next.value).toBe(undefined);
     });
   });
 });

--- a/packages/veritone-redux-common/src/modules/engineResults/index.js
+++ b/packages/veritone-redux-common/src/modules/engineResults/index.js
@@ -78,7 +78,7 @@ export const isDisplayingUserEditedOutput = (state, engineId) => {
   return !!find(results, { userEdited: true });
 };
 
-export const getEngineResultsQuery = `query engineResults($tdoId: I!, $engineIds: [ID!]!, $startOffsetMs: Int, $stopOffsetMs: Int, $ignoreUserEdited: Boolean) {
+export const getEngineResultsQuery = `query engineResults($tdoId: ID!, $engineIds: [ID!]!, $startOffsetMs: Int, $stopOffsetMs: Int, $ignoreUserEdited: Boolean) {
   engineResults(tdoId: $tdoId, engineIds: $engineIds, startOffsetMs: $startOffsetMs, stopOffsetMs: $stopOffsetMs, ignoreUserEdited: $ignoreUserEdited) {
     records {
       tdoId

--- a/packages/veritone-redux-common/src/modules/engineResults/index.js
+++ b/packages/veritone-redux-common/src/modules/engineResults/index.js
@@ -9,7 +9,7 @@ export const FETCH_ENGINE_RESULTS = `vtn/${namespace}/FETCH_ENGINE_RESULTS`;
 export const FETCH_ENGINE_RESULTS_SUCCESS = `vtn/${namespace}/FETCH_ENGINE_RESULTS_SUCCESS`;
 export const FETCH_ENGINE_RESULTS_FAILURE = `vtn/${namespace}/FETCH_ENGINE_RESULTS_FAILURE`;
 
-const defaultState = {
+export const defaultState = {
   engineResultsMappedByEngineId: {},
   fetchedEngineResults: {},
   isFetchingEngineResults: false,
@@ -78,6 +78,20 @@ export const isDisplayingUserEditedOutput = (state, engineId) => {
   return !!find(results, { userEdited: true });
 };
 
+export const getEngineResultsQuery = `query engineResults($tdoId: I!, $engineIds: [ID!]!, $startOffsetMs: Int, $stopOffsetMs: Int, $ignoreUserEdited: Boolean) {
+  engineResults(tdoId: $tdoId, engineIds: $engineIds, startOffsetMs: $startOffsetMs, stopOffsetMs: $stopOffsetMs, ignoreUserEdited: $ignoreUserEdited) {
+    records {
+      tdoId
+      engineId
+      startOffsetMs
+      stopOffsetMs
+      jsondata
+      assetId
+      userEdited
+    }
+  }
+}`;
+
 export const fetchEngineResults = ({
   tdo,
   engineId,
@@ -85,20 +99,6 @@ export const fetchEngineResults = ({
   stopOffsetMs,
   ignoreUserEdited = false
 } = {}) => async (dispatch, getState) => {
-  const getEngineResultsQuery = `query engineResults($tdoId: ID!, $engineIds: [ID!]!, $startOffsetMs: Int, $stopOffsetMs: Int, $ignoreUserEdited: Boolean) {
-    engineResults(tdoId: $tdoId, engineIds: $engineIds, startOffsetMs: $startOffsetMs, stopOffsetMs: $stopOffsetMs, ignoreUserEdited: $ignoreUserEdited) {
-      records {
-        tdoId
-        engineId
-        startOffsetMs
-        stopOffsetMs
-        jsondata
-        assetId
-        userEdited
-      }
-    }
-  }`;
-
   const variables = { tdoId: tdo.id, engineIds: [engineId], ignoreUserEdited };
   if (startOffsetMs) {
     variables.startOffsetMs = startOffsetMs;

--- a/packages/veritone-redux-common/src/modules/engineResults/index.js
+++ b/packages/veritone-redux-common/src/modules/engineResults/index.js
@@ -1,0 +1,120 @@
+import { createReducer } from 'helpers/redux';
+import { callGraphQL } from 'helpers/api';
+import { get, groupBy, find } from 'lodash';
+
+export const namespace = 'engineResults';
+
+export const FETCH_ENGINE_RESULTS = `vtn/${namespace}/FETCH_ENGINE_RESULTS`;
+export const FETCH_ENGINE_RESULTS_SUCCESS = `vtn/${namespace}/FETCH_ENGINE_RESULTS_SUCCESS`;
+export const FETCH_ENGINE_RESULTS_FAILURE = `vtn/${namespace}/FETCH_ENGINE_RESULTS_FAILURE`;
+
+const defaultState = {
+  engineResultsMappedByEngineId: {},
+  fetchedEngineResults: {},
+  isFetchingEngineResults: false,
+  fetchEngineResultsError: null
+};
+
+export default createReducer(defaultState, {
+  [FETCH_ENGINE_RESULTS](state, action) {
+    console.log('FETCH_ENGINE_RESULTS', state, action);
+    return {
+      ...state,
+      isFetchingEngineResults: true
+    };
+  },
+  [FETCH_ENGINE_RESULTS_SUCCESS](state, action) {
+    console.log('FETCH_ENGINE_RESULTS_SUCCESS', state, action);
+    if (action.payload.errors) {
+      return this[FETCH_ENGINE_RESULTS_FAILURE](state, action);
+    }
+
+    const results = get(action, 'payload.engineResults.records').map(result => {
+      return {
+        ...result.jsondata,
+        userEdited: result.userEdited,
+        assetId: result.assetId
+      };
+    });
+    const resultsGroupedByEngineId = groupBy(results, 'sourceEngineId');
+
+    return {
+      ...state,
+      isFetchingEngineResults: false,
+      fetchEngineResultsError: null,
+      engineResultsMappedByEngineId: {
+        ...state.engineResultsMappedByEngineId,
+        ...resultsGroupedByEngineId
+      }
+    };
+  },
+  [FETCH_ENGINE_RESULTS_FAILURE](state, action) {
+    return {
+      ...state,
+      isFetchingEngineResults: false,
+      fetchEngineResultsError:
+        get(action, 'payload[0].message') || 'Error fetching engine results'
+    };
+  }
+});
+
+function local(state) {
+  return state[namespace];
+}
+
+export const engineResults = state =>
+  local(state).engineResultsMappedByEngineId;
+
+export const engineResultsByEngineId = (state, engineId) =>
+  get(local(state), ['engineResultsMappedByEngineId', engineId], []);
+
+export const isFetchingEngineResults = state =>
+  local(state).isFetchingEngineResults;
+
+export const isDisplayingUserEditedOutput = (state, engineId) => {
+  const results = engineResultsByEngineId(state, engineId);
+  return !!find(results, { userEdited: true });
+};
+
+export const fetchEngineResults = ({
+  tdo,
+  engineId,
+  startOffsetMs,
+  stopOffsetMs,
+  ignoreUserEdited = false
+} = {}) => async (dispatch, getState) => {
+  const getEngineResultsQuery = `query engineResults($tdoId: ID!, $engineIds: [ID!]!, $startOffsetMs: Int, $stopOffsetMs: Int, $ignoreUserEdited: Boolean) {
+    engineResults(tdoId: $tdoId, engineIds: $engineIds, startOffsetMs: $startOffsetMs, stopOffsetMs: $stopOffsetMs, ignoreUserEdited: $ignoreUserEdited) {
+      records {
+        tdoId
+        engineId
+        startOffsetMs
+        stopOffsetMs
+        jsondata
+        assetId
+        userEdited
+      }
+    }
+  }`;
+
+  const variables = { tdoId: tdo.id, engineIds: [engineId], ignoreUserEdited };
+  if (startOffsetMs) {
+    variables.startOffsetMs = startOffsetMs;
+  }
+  if (stopOffsetMs) {
+    variables.stopOffsetMs = stopOffsetMs;
+  }
+  const response = await callGraphQL({
+    actionTypes: [
+      FETCH_ENGINE_RESULTS,
+      FETCH_ENGINE_RESULTS_SUCCESS,
+      FETCH_ENGINE_RESULTS_FAILURE
+    ],
+    query: getEngineResultsQuery,
+    variables,
+    dispatch,
+    getState
+  });
+
+  return response;
+};

--- a/packages/veritone-redux-common/src/modules/engineResults/index.js
+++ b/packages/veritone-redux-common/src/modules/engineResults/index.js
@@ -1,6 +1,7 @@
 import { createReducer } from 'helpers/redux';
 import { callGraphQL } from 'helpers/api';
-import { get, groupBy, find } from 'lodash';
+import { get, groupBy, find, forEach } from 'lodash';
+import { guid } from 'helpers/misc';
 
 export const namespace = 'engineResults';
 
@@ -17,19 +18,20 @@ const defaultState = {
 
 export default createReducer(defaultState, {
   [FETCH_ENGINE_RESULTS](state, action) {
-    console.log('FETCH_ENGINE_RESULTS', state, action);
     return {
       ...state,
       isFetchingEngineResults: true
     };
   },
   [FETCH_ENGINE_RESULTS_SUCCESS](state, action) {
-    console.log('FETCH_ENGINE_RESULTS_SUCCESS', state, action);
     if (action.payload.errors) {
       return this[FETCH_ENGINE_RESULTS_FAILURE](state, action);
     }
 
     const results = get(action, 'payload.engineResults.records').map(result => {
+      forEach(get(result, 'jsondata.series'), seriesItem => {
+        seriesItem.guid = guid();
+      });
       return {
         ...result.jsondata,
         userEdited: result.userEdited,

--- a/packages/veritone-redux-common/src/modules/engineResults/index.test.js
+++ b/packages/veritone-redux-common/src/modules/engineResults/index.test.js
@@ -1,0 +1,151 @@
+import { makeMockStore } from 'helpers/test/redux';
+import nock from 'nock';
+import * as engineResultsModule from './';
+
+const mockStore = makeMockStore();
+
+describe('engineResults module reducer', () => {
+  describe('fetchEngineResults', () => {
+    const mockFetchEngineResultsVars = {
+      tdoId: "123",
+      engineIds: ["myengine1"],
+      ignoreUserEdited: false,
+      stopOffsetMs: 5000
+    };
+
+    const mockEngineResultsResponse = {
+      data: {
+        engineResults: {
+          records: [
+            {
+              assetId: "test-asset-123",
+              engineId: "myengine1",
+              jsondata: {
+                series: [
+                  {startTimeMs:0,stopTimeMs: 2500, words:[{word:"hello", confidence: 1}]},
+                  {startTimeMs:2501,stopTimeMs: 5000, words:[{word:"world", confidence: 1}]}
+                ]
+              },
+              startOffsetMs: 0,
+              stopOffsetMs: 5000,
+              tdoId: "123",
+              userEdited: true
+            }
+          ]
+        }
+      }
+    };
+
+    const mockEngineResultsErrorResponse = {
+      data: {},
+      errors: [{message: 'An error message'}]
+    };
+
+    it('should dispatch FETCH_ENGINE_RESULTS and FETCH_ENGINE_RESULTS_SUCCESS on successful response', () => {
+      const store = mockStore({
+        config: {
+          apiRoot: 'http://www.test.com:80',
+          graphQLEndpoint: "graphql"
+        },
+        auth: {
+          sessionToken: '123'
+        },
+        engineResults: engineResultsModule.defaultState
+      });
+
+      const api = nock('http://www.test.com')
+        .post('/graphql')
+        .reply(200, mockEngineResultsResponse);
+
+      const expectedActions = [
+        {
+          type: engineResultsModule.FETCH_ENGINE_RESULTS,
+          meta: {
+            operationName: undefined,
+            query: engineResultsModule.getEngineResultsQuery,
+            variables: mockFetchEngineResultsVars
+          }
+        },
+        {
+          type: engineResultsModule.FETCH_ENGINE_RESULTS_SUCCESS,
+          meta: {
+            operationName: undefined,
+            query: engineResultsModule.getEngineResultsQuery,
+            variables: mockFetchEngineResultsVars
+          },
+          payload: mockEngineResultsResponse.data
+        }
+      ];
+
+      const engineResults = engineResultsModule.fetchEngineResults({
+        tdo: {
+          id: "123"
+        },
+        engineId: "myengine1",
+        startOffsetMs: 0,
+        stopOffsetMs: 5000,
+        ignoreUserEdited: false
+      });
+
+      engineResults(store.dispatch, store.getState).then(() => {
+        expect(store.getActions()).toEqual(expectedActions);
+        api.done();
+        return;
+      });
+    });
+
+    it('should dispatch FETCH_ENGINE_RESULTS and FETCH_ENGINE_RESULTS_FAILURE on successful response', () => {
+      const store = mockStore({
+        config: {
+          apiRoot: 'http://www.test.com',
+          graphQLEndpoint: "graphql"
+        },
+        auth: {
+          sessionToken: '123'
+        },
+        engineResults: engineResultsModule.defaultState
+      });
+
+      const api = nock('http://www.test.com')
+        .post('/graphql')
+        .reply(400, mockEngineResultsErrorResponse);
+
+      const engineResults = engineResultsModule.fetchEngineResults({
+        tdo: {
+          id: "123"
+        },
+        engineId: "myengine1",
+        startOffsetMs: 0,
+        stopOffsetMs: 5000,
+        ignoreUserEdited: false
+      });
+
+      const expectedActions = [
+        {
+          type: engineResultsModule.FETCH_ENGINE_RESULTS,
+          meta: {
+            operationName: undefined,
+            query: engineResultsModule.getEngineResultsQuery,
+            variables: mockFetchEngineResultsVars
+          }
+        },
+        {
+          error: true,
+          type: engineResultsModule.FETCH_ENGINE_RESULTS_FAILURE,
+          meta: {
+            operationName: undefined,
+            query: engineResultsModule.getEngineResultsQuery,
+            variables: mockFetchEngineResultsVars
+          },
+          payload: mockEngineResultsErrorResponse.errors
+        }
+      ];
+
+      engineResults(store.dispatch, store.getState).then(() => {
+        expect(store.getActions()).toEqual(expectedActions);
+        api.done();
+        return;
+      });
+    });
+  });
+});

--- a/packages/veritone-redux-common/src/modules/index.js
+++ b/packages/veritone-redux-common/src/modules/index.js
@@ -50,3 +50,9 @@ export const confirmation = {
   ...confirmationModule,
   confirmationRootSaga
 };
+
+import engineResultsReducer, * as engineResultsModule from './engineResults';
+export const engineResults = {
+  reducer: engineResultsReducer,
+  ...engineResultsModule
+};

--- a/packages/veritone-redux-common/test/testSuitePolyfills.js
+++ b/packages/veritone-redux-common/test/testSuitePolyfills.js
@@ -1,1 +1,3 @@
+import fetch from 'node-fetch';
 global.requestAnimationFrame = require('raf');
+global.fetch = fetch;

--- a/packages/veritone-widgets/src/redux/modules/mediaDetails/faceEngineOutput/index.js
+++ b/packages/veritone-widgets/src/redux/modules/mediaDetails/faceEngineOutput/index.js
@@ -233,11 +233,6 @@ function local(state) {
   return state[namespace];
 }
 
-export const isDisplayingUserEditedOutput = (state, engineId) => {
-  const engineResults = getFaceDataByEngine(state, engineId);
-  return !!find(engineResults, { userEdited: true });
-};
-
 export const getFaceDataByEngine = (state, engineId) => {
   return engineResultsModule.engineResultsByEngineId(state, engineId);
 };

--- a/packages/veritone-widgets/src/redux/modules/mediaDetails/faceEngineOutput/index.js
+++ b/packages/veritone-widgets/src/redux/modules/mediaDetails/faceEngineOutput/index.js
@@ -1,11 +1,5 @@
 export const namespace = 'face-engine-output';
 
-export const FETCH_ENGINE_RESULTS = `vtn/${namespace}/FETCH_ENGINE_RESULTS`;
-export const FETCHING_ENGINE_RESULTS = `vtn/${namespace}/FETCHING_ENGINE_RESULTS`;
-export const FETCH_ENGINE_RESULTS_SUCCESS = `vtn/${namespace}/FETCH_ENGINE_RESULTS_SUCCESS`;
-export const FETCH_ENGINE_RESULTS_FAILURE = `vtn/${namespace}/FETCH_ENGINE_RESULTS_FAILURE`;
-export const DONE_FETCHING_ENGINE_RESULTS = `vtn/${namespace}/DONE_FETCHING_ENGINE_RESULTS`;
-
 export const FETCH_ENTITIES = `vtn/${namespace}/FETCH_ENTITIES`;
 export const FETCH_ENTITIES_SUCCESS = `vtn/${namespace}/FETCH_ENTITIES_SUCCESS`;
 export const FETCH_ENTITIES_FAILURE = `vtn/${namespace}/FETCH_ENTITIES_FAILURE`;
@@ -33,30 +27,24 @@ export const CLOSE_CONFIRMATION_DIALOG = `vtn/${namespace}/CLOSE_CONFIMATION_DIA
 import {
   get,
   map,
-  findIndex,
   find,
-  groupBy,
-  forEach,
   keyBy,
   isEmpty,
-  set,
   pick,
   flatten,
-  pullAt,
-  noop
+  noop,
+  reduce
 } from 'lodash';
-import { helpers } from 'veritone-redux-common';
+import { helpers, modules } from 'veritone-redux-common';
 import { createSelector } from 'reselect';
 
 const { createReducer } = helpers;
+const { engineResults: engineResultsModule } = modules;
 
 const defaultState = {
-  engineResultsByEngineId: {},
-  fetchedEngineResults: {},
   entities: {},
   libraries: {},
   entitySearchResults: [],
-  isFetchingEngineResults: false,
   isFetchingEntities: false,
   isFetchingLibraries: false,
   isSearchingEntities: false,
@@ -68,52 +56,6 @@ const defaultState = {
 };
 
 const reducer = createReducer(defaultState, {
-  [FETCHING_ENGINE_RESULTS](state, action) {
-    return {
-      ...state,
-      isFetchingEngineResults: true
-    };
-  },
-  [DONE_FETCHING_ENGINE_RESULTS](state, action) {
-    return {
-      ...state,
-      isFetchingEngineResults: false
-    };
-  },
-  [FETCH_ENGINE_RESULTS_SUCCESS](state, action) {
-    if (action.payload.errors) {
-      return this[FETCH_ENGINE_RESULTS_FAILURE](state, action);
-    }
-
-    const engineResults = action.payload.data.engineResults.records;
-    const { startOffsetMs, stopOffsetMs, ignoreUserEdited } = action.meta;
-
-    const previousResultsByEngineId = state.engineResultsByEngineId || {};
-    const resultsGroupedByEngineId = groupBy(engineResults, 'engineId');
-
-    forEach(resultsGroupedByEngineId, (results, engineId) => {
-      previousResultsByEngineId[engineId] = map(results, 'jsondata');
-    });
-
-    return {
-      ...state,
-      engineResultsByEngineId: {
-        ...previousResultsByEngineId
-      },
-      fetchedEngineResults: {
-        [action.meta.engineId]: {
-          [`${startOffsetMs}-${stopOffsetMs}`]: true
-        }
-      },
-      displayUserEdited: !ignoreUserEdited
-    };
-  },
-  [FETCH_ENGINE_RESULTS_FAILURE](state, { payload, meta }) {
-    return {
-      ...state,
-      displayUserEdited: false
-    };
-  },
   [FETCH_ENTITIES](state, action) {
     return {
       ...state,
@@ -222,31 +164,14 @@ const reducer = createReducer(defaultState, {
   },
   [ADD_DETECTED_FACE](state, action) {
     const { faceObj, selectedEngineId, entity } = action.payload;
-    const objectCriteria = pick(faceObj.object, ['uri', 'boundingPoly']);
-
-    const detectedFacePath = state.engineResultsByEngineId[
-      selectedEngineId
-    ].reduce((acc, engineResult, engineResultIdx) => {
-      const faceIdx = findIndex(engineResult.series, {
-        object: objectCriteria
-      });
-
-      return faceIdx > -1 ? `[${engineResultIdx}].series[${faceIdx}]` : acc;
-    }, '');
-
-    if (!detectedFacePath.length) {
-      return {
-        ...state
-      };
-    }
 
     return {
       ...state,
       facesDetectedByUser: {
         ...state.facesDetectedByUser,
-        [selectedEngineId]: {
-          ...state.facesDetectedByUser[selectedEngineId],
-          [detectedFacePath]: {
+        [selectedEngineId]: [
+          ...(state.facesDetectedByUser[selectedEngineId] || []),
+          {
             ...faceObj,
             object: {
               ...faceObj.object,
@@ -254,7 +179,7 @@ const reducer = createReducer(defaultState, {
               libraryId: entity.libraryId
             }
           }
-        }
+        ]
       },
       entities: {
         ...state.entities,
@@ -264,33 +189,16 @@ const reducer = createReducer(defaultState, {
   },
   [REMOVE_DETECTED_FACE](state, action) {
     const { faceObj, selectedEngineId } = action.payload;
-    const objectCriteria = pick(faceObj.object, ['uri', 'boundingPoly']);
-
-    const detectedFacePath = state.engineResultsByEngineId[
-      selectedEngineId
-    ].reduce((acc, engineResult, engineResultIdx) => {
-      const faceIdx = findIndex(engineResult.series, {
-        object: objectCriteria
-      });
-
-      return faceIdx > -1 ? [engineResultIdx, faceIdx] : acc;
-    }, []);
-
-    if (!detectedFacePath.length) {
-      return {
-        ...state
-      };
-    }
-
-    const removedFaces = state.facesRemovedByUser[selectedEngineId]
-      ? [...state.facesRemovedByUser[selectedEngineId], detectedFacePath]
-      : [detectedFacePath];
 
     return {
       ...state,
       facesRemovedByUser: {
-        ...state.facesRemovedByUser,
-        [selectedEngineId]: removedFaces
+        [selectedEngineId]: [
+          ...(state.facesRemovedByUser[selectedEngineId] || []),
+          {
+            ...faceObj
+          }
+        ]
       }
     };
   },
@@ -323,40 +231,14 @@ function local(state) {
   return state[namespace];
 }
 
-/* ENGINE RESULTS */
-export const fetchEngineResults = meta => ({
-  type: FETCH_ENGINE_RESULTS,
-  meta
-});
-export const fetchingEngineResults = meta => ({
-  type: FETCHING_ENGINE_RESULTS,
-  meta
-});
-export const doneFetchingEngineResults = () => ({
-  type: DONE_FETCHING_ENGINE_RESULTS
-});
-export const fetchEngineResultsSuccess = (payload, meta) => ({
-  type: FETCH_ENGINE_RESULTS_SUCCESS,
-  payload,
-  meta
-});
-export const fetchEngineResultsFailure = (error, meta) => ({
-  type: FETCH_ENGINE_RESULTS_FAILURE,
-  error,
-  meta
-});
-
-export function isFetchingEngineResults(state) {
-  return local(state).isFetchingEngineResults;
-}
-
 export const isDisplayingUserEditedOutput = (state, engineId) => {
   const engineResults = getFaceDataByEngine(state, engineId);
   return !!find(engineResults, { userEdited: true });
 };
 
-export const getFaceDataByEngine = (state, engineId) =>
-  get(local(state), ['engineResultsByEngineId', engineId]);
+export const getFaceDataByEngine = (state, engineId) => {
+  return engineResultsModule.engineResultsByEngineId(state, engineId);
+};
 
 export const getUserDetectedFaces = (state, engineId) =>
   get(local(state), ['facesDetectedByUser', engineId]);
@@ -367,9 +249,6 @@ export const getUserRemovedFaces = (state, engineId) =>
 export const pendingUserEdits = (state, engineId) =>
   !isEmpty(getUserDetectedFaces(state, engineId)) ||
   !isEmpty(getUserRemovedFaces(state, engineId));
-
-export const fetchedEngineResultByEngineId = (state, engineId) =>
-  get(local(state), ['fetchedEngineResults', engineId], []);
 
 /* ENTITIES */
 export const fetchingEntities = meta => ({
@@ -581,36 +460,23 @@ function addUserDetectedFaces(
   userDetectedFaces,
   userRemovedFaces
 ) {
-  const updatedFaceData = map(engineResults, data => ({
+  return map(engineResults, data => ({
     taskId: data.taskId,
     assetId: data.assetId,
     sourceEngineId: data.sourceEngineId,
-    series: [...data.series]
+    series: reduce(
+      data.series,
+      (accumulator, originalFaceObj) => {
+        if (find(userRemovedFaces, { guid: originalFaceObj.guid })) {
+          return accumulator;
+        }
+        return [
+          ...accumulator,
+          find(userDetectedFaces, { guid: originalFaceObj.guid }) ||
+            originalFaceObj
+        ];
+      },
+      []
+    )
   }));
-
-  if (userDetectedFaces) {
-    forEach(userDetectedFaces, (faceObj, faceObjPath) => {
-      set(updatedFaceData, faceObjPath, faceObj);
-    });
-  }
-
-  if (userRemovedFaces) {
-    const facesToRemove = userRemovedFaces.reduce((acc, faceObjPath) => {
-      const [engineResultIdx, faceIdx] = faceObjPath;
-
-      if (!acc[engineResultIdx]) {
-        acc[engineResultIdx] = [faceIdx];
-      } else {
-        acc[engineResultIdx].push(faceIdx);
-      }
-
-      return acc;
-    }, {});
-
-    forEach(facesToRemove, (faces, engineResultIdx) => {
-      pullAt(updatedFaceData[engineResultIdx].series, faces); // eslint-disable-line
-    });
-  }
-
-  return updatedFaceData;
 }

--- a/packages/veritone-widgets/src/redux/modules/mediaDetails/faceEngineOutput/index.js
+++ b/packages/veritone-widgets/src/redux/modules/mediaDetails/faceEngineOutput/index.js
@@ -33,7 +33,8 @@ import {
   pick,
   flatten,
   noop,
-  reduce
+  reduce,
+  cloneDeep
 } from 'lodash';
 import { helpers, modules } from 'veritone-redux-common';
 import { createSelector } from 'reselect';
@@ -193,6 +194,7 @@ const reducer = createReducer(defaultState, {
     return {
       ...state,
       facesRemovedByUser: {
+        ...state.facesRemovedByUser,
         [selectedEngineId]: [
           ...(state.facesRemovedByUser[selectedEngineId] || []),
           {
@@ -430,9 +432,9 @@ export const getFaces = createSelector(
 
 /* HELPERS */
 export const getFaceEngineAssetData = (state, engineId) => {
-  const engineResults = getFaceDataByEngine(state, engineId);
-  const userDetectedFaces = getUserDetectedFaces(state, engineId);
-  const userRemovedFaces = getUserRemovedFaces(state, engineId);
+  const engineResults = cloneDeep(getFaceDataByEngine(state, engineId));
+  const userDetectedFaces = cloneDeep(getUserDetectedFaces(state, engineId)) || [];
+  const userRemovedFaces = cloneDeep(getUserRemovedFaces(state, engineId)) || [];
 
   const allJsonData = addUserDetectedFaces(
     engineResults,

--- a/packages/veritone-widgets/src/redux/modules/mediaDetails/faceEngineOutput/saga.js
+++ b/packages/veritone-widgets/src/redux/modules/mediaDetails/faceEngineOutput/saga.js
@@ -8,65 +8,20 @@ import {
   select
 } from 'redux-saga/effects';
 import { delay } from 'redux-saga';
-import { get, isUndefined, isEmpty } from 'lodash';
+import { get, isEmpty } from 'lodash';
 import { modules } from 'veritone-redux-common';
 import * as faceEngineOutput from '.';
 import * as gqlQuery from './queries';
 
 import callGraphQLApi from '../../../../shared/callGraphQLApi';
 
-const { auth: authModule, config: configModule } = modules;
+const {
+  auth: authModule,
+  config: configModule,
+  engineResults: engineResultsModule
+} = modules;
 
 /* WATCH FUNCTIONS */
-function* loadEngineResults(
-  tdo,
-  engineId,
-  startOffsetMs,
-  stopOffsetMs,
-  ignoreUserEdited = false
-) {
-  const config = yield select(configModule.getConfig);
-  const token = yield select(authModule.selectSessionToken);
-
-  const { apiRoot, graphQLEndpoint } = config;
-  const graphQLUrl = `${apiRoot}/${graphQLEndpoint}`;
-  const variables = {
-    tdoId: tdo.id,
-    engineIds: [engineId],
-    ignoreUserEdited
-  };
-
-  const meta = {
-    engineId,
-    startOffsetMs,
-    stopOffsetMs
-  };
-
-  if (!isUndefined(startOffsetMs)) {
-    variables.startOffsetMs = startOffsetMs;
-  }
-  if (!isUndefined(stopOffsetMs)) {
-    variables.stopOffsetMs = stopOffsetMs;
-  }
-
-  try {
-    yield put(faceEngineOutput.fetchingEngineResults(meta));
-
-    const response = yield call(callGraphQLApi, {
-      endpoint: graphQLUrl,
-      query: gqlQuery.getEngineResultsQuery,
-      variables: variables,
-      token
-    });
-
-    yield put(faceEngineOutput.fetchEngineResultsSuccess(response, meta));
-  } catch (error) {
-    yield put(faceEngineOutput.fetchEngineResultsFailure(error, meta));
-  } finally {
-    yield put(faceEngineOutput.doneFetchingEngineResults(meta));
-  }
-}
-
 function* fetchEntities(entityIds) {
   const entityQueries = gqlQuery.getEntities(entityIds);
   const config = yield select(configModule.getConfig);
@@ -180,12 +135,15 @@ function* searchForEntities(action) {
 }
 
 function* onMount(tdo, selectedEngineId) {
-  yield call(
-    loadEngineResults,
-    tdo,
-    selectedEngineId,
-    0,
-    Date.parse(tdo.stopDateTime) - Date.parse(tdo.startDateTime)
+  yield put(
+    engineResultsModule.fetchEngineResults({
+      tdo: tdo,
+      engineId: selectedEngineId,
+      startOffsetMs: 0,
+      stopOffsetMs:
+        Date.parse(tdo.stopDateTime) - Date.parse(tdo.startDateTime),
+      ignoreUserEdited: false
+    })
   );
 }
 
@@ -193,11 +151,10 @@ function* onMount(tdo, selectedEngineId) {
 
 function* watchFetchEngineResultsSuccess() {
   yield takeEvery(
-    action => action.type === faceEngineOutput.FETCH_ENGINE_RESULTS_SUCCESS,
+    action => action.type === engineResultsModule.FETCH_ENGINE_RESULTS_SUCCESS,
     function*(action) {
       if (!action.payload.errors) {
-        // const entityIds = {};
-        const engineResults = get(action.payload.data, 'engineResults.records');
+        const engineResults = get(action.payload, 'engineResults.records');
 
         if (engineResults && engineResults.length) {
           const entityIds = engineResults.reduce((result, engineResult) => {
@@ -242,30 +199,12 @@ function* watchSearchEntities() {
   );
 }
 
-function* watchFetchEngineResults() {
-  yield takeEvery(
-    action => action.type === faceEngineOutput.FETCH_ENGINE_RESULTS,
-    function*(action) {
-      const { tdo, selectedEngineId, ignoreUserEdited } = action.meta;
-      yield call(
-        loadEngineResults,
-        tdo,
-        selectedEngineId,
-        0,
-        Date.parse(tdo.stopDateTime) - Date.parse(tdo.startDateTime),
-        ignoreUserEdited
-      );
-    }
-  );
-}
-
 export default function* root({ tdo, selectedEngineId }) {
   yield all([
-    fork(onMount, tdo, selectedEngineId),
-    fork(watchFetchEngineResults),
     fork(watchFetchEngineResultsSuccess),
     fork(watchFetchLibraries),
     fork(watchCreateEntity),
-    fork(watchSearchEntities)
+    fork(watchSearchEntities),
+    fork(onMount, tdo, selectedEngineId)
   ]);
 }

--- a/packages/veritone-widgets/src/redux/modules/mediaDetails/index.js
+++ b/packages/veritone-widgets/src/redux/modules/mediaDetails/index.js
@@ -650,11 +650,6 @@ const local = state => state[namespace];
 
 export const getEngineCategories = (state, widgetId) =>
   get(local(state), [widgetId, 'engineCategories']);
-export const getEngineResultsByEngineId = (state, widgetId) =>
-  get(local(state), [widgetId, 'engineResultsByEngineId']);
-export const getEngineResultRequestsByEngineId = (state, widgetId, engineId) =>
-  get(local(state), [widgetId, 'engineResultRequestsByEngineId', engineId]) ||
-  [];
 export const getTdo = (state, widgetId) => get(local(state), [widgetId, 'tdo']);
 export const isLoadingTdo = (state, widgetId) =>
   get(local(state), [widgetId, 'isLoadingTdo']);

--- a/packages/veritone-widgets/src/redux/modules/mediaDetails/index.js
+++ b/packages/veritone-widgets/src/redux/modules/mediaDetails/index.js
@@ -1,25 +1,9 @@
-import {
-  get,
-  has,
-  findLastIndex,
-  findIndex,
-  groupBy,
-  forEach,
-  map,
-  values,
-  uniqBy,
-  keyBy,
-  isMatch,
-  noop
-} from 'lodash';
+import { get, has, values, uniqBy, keyBy, noop } from 'lodash';
 import { helpers } from 'veritone-redux-common';
 const { createReducer } = helpers;
 
 export const LOAD_ENGINE_CATEGORIES_SUCCESS = 'LOAD_ENGINE_CATEGORIES_SUCCESS';
 export const LOAD_ENGINE_CATEGORIES_FAILURE = 'LOAD_ENGINE_CATEGORIES_FAILURE';
-export const LOAD_ENGINE_RESULTS = 'LOAD_ENGINE_RESULTS';
-export const LOAD_ENGINE_RESULTS_SUCCESS = 'LOAD_ENGINE_RESULTS_SUCCESS';
-export const LOAD_ENGINE_RESULTS_FAILURE = 'LOAD_ENGINE_RESULTS_FAILURE';
 export const CLEAR_ENGINE_RESULTS_BY_ENGINE_ID =
   'CLEAR_ENGINE_RESULTS_BY_ENGINE_ID';
 export const LOAD_TDO = 'LOAD_TDO';
@@ -70,8 +54,6 @@ export const namespace = 'mediaDetails';
 
 const defaultMDPState = {
   engineCategories: [],
-  engineResultsByEngineId: {},
-  engineResultRequestsByEngineId: {}, // A list of engine result request so we don't request already fetched data.
   tdo: null,
   isLoadingTdo: false,
   selectedEngineCategory: null,
@@ -143,161 +125,6 @@ export default createReducer(defaultState, {
         error: errorMessage || 'unknown error',
         warning: warn || null,
         engineCategories: []
-      }
-    };
-  },
-  [LOAD_ENGINE_RESULTS](
-    state,
-    {
-      payload,
-      meta: { widgetId }
-    }
-  ) {
-    let resultRequests =
-      state[widgetId].engineResultRequestsByEngineId[payload.engineId] || [];
-    const requestInsertIndex = findLastIndex(resultRequests, request => {
-      return request.stopOffsetMs < payload.startOffsetMs;
-    });
-    resultRequests = [
-      ...resultRequests.slice(0, requestInsertIndex + 1),
-      {
-        startOffsetMs: payload.startOffsetMs,
-        stopOffsetMs: payload.stopOffsetMs,
-        status: 'FETCHING'
-      },
-      ...resultRequests.slice(requestInsertIndex + 1)
-    ];
-
-    let engineResults =
-      state[widgetId].engineResultsByEngineId[payload.engineId] || [];
-    let resultInsertIndex = findLastIndex(engineResults, result => {
-      return (
-        result.series[result.series.length - 1].startTimeMs <=
-        payload.startOffsetMs
-      );
-    });
-
-    return {
-      ...state,
-      [widgetId]: {
-        ...state[widgetId],
-        engineResultRequestsByEngineId: {
-          ...state[widgetId].engineResultRequestsByEngineId,
-          [payload.engineId]: [...resultRequests]
-        },
-        engineResultsByEngineId: {
-          ...state[widgetId].engineResultsByEngineId,
-          [payload.engineId]: [
-            ...engineResults.slice(0, resultInsertIndex + 1),
-            {
-              startOffsetMs: payload.startOffsetMs,
-              stopOffsetMs: payload.stopOffsetMs,
-              status: 'FETCHING'
-            },
-            ...engineResults.slice(resultInsertIndex + 1)
-          ]
-        }
-      }
-    };
-  },
-  [LOAD_ENGINE_RESULTS_SUCCESS](
-    state,
-    {
-      payload,
-      meta: { widgetId, startOffsetMs, stopOffsetMs, engineId }
-    }
-  ) {
-    const previousResultsByEngineId =
-      state[widgetId].engineResultsByEngineId || {};
-    const engineResultRequestsById =
-      state[widgetId].engineResultRequestsByEngineId;
-    // It is possible results were requested by
-    let resultsGroupedByEngineId;
-    if (payload.length) {
-      resultsGroupedByEngineId = groupBy(payload, 'engineId');
-    } else {
-      // handle no results case
-      const tdoId = state[widgetId].tdo.id;
-      resultsGroupedByEngineId = {};
-      resultsGroupedByEngineId[engineId] = [
-        {
-          startOffsetMs,
-          stopOffsetMs,
-          tdoId,
-          engineId
-        }
-      ];
-    }
-
-    forEach(resultsGroupedByEngineId, (results, engineId) => {
-      // process only results with jsondata
-      const resultsWithData = results.filter(
-        result => !!result && !!result.jsondata
-      );
-      if (!previousResultsByEngineId[engineId]) {
-        // Data hasn't been retrieved for this engineId yet
-        previousResultsByEngineId[engineId] = map(resultsWithData, 'jsondata');
-      } else {
-        // New results need to be merged with previously fetched results
-        let insertionIndex = findIndex(previousResultsByEngineId[engineId], {
-          startOffsetMs,
-          stopOffsetMs,
-          status: 'FETCHING'
-        });
-
-        // TODO: fitler out any duplicate data that overflows time chunks.
-        previousResultsByEngineId[engineId] = [
-          ...previousResultsByEngineId[engineId].slice(0, insertionIndex),
-          ...map(resultsWithData, 'jsondata'),
-          ...previousResultsByEngineId[engineId].slice(insertionIndex + 1)
-        ];
-      }
-      const fetchingOffsetRequest = {
-        startOffsetMs: startOffsetMs,
-        stopOffsetMs: stopOffsetMs,
-        status: 'FETCHING'
-      };
-      engineResultRequestsById[engineId] = engineResultRequestsById[
-        engineId
-      ].map(request => {
-        if (isMatch(request, fetchingOffsetRequest)) {
-          return {
-            ...request,
-            status: 'SUCCESS'
-          };
-        }
-        return request;
-      });
-    });
-
-    return {
-      ...state,
-      [widgetId]: {
-        ...state[widgetId],
-        error: null,
-        engineResultsByEngineId: {
-          ...previousResultsByEngineId
-        },
-        engineResultRequestsByEngineId: {
-          ...engineResultRequestsById
-        }
-      }
-    };
-  },
-  [LOAD_ENGINE_RESULTS_FAILURE](
-    state,
-    {
-      meta: { error, startOffsetMs, stopOffsetMs, engineId, widgetId }
-    }
-  ) {
-    const errorMessage =
-      `Error fetching engine ${engineId} results for offset ${startOffsetMs} - ${stopOffsetMs} :` +
-      get(error, 'message', error);
-    return {
-      ...state,
-      [widgetId]: {
-        ...state[widgetId],
-        error: errorMessage || 'uknown error'
       }
     };
   },
@@ -879,37 +706,6 @@ export const loadEngineCategoriesSuccess = (widgetId, result) => ({
 export const loadEngineCategoriesFailure = (widgetId, { error }) => ({
   type: LOAD_ENGINE_CATEGORIES_FAILURE,
   meta: { error, widgetId }
-});
-
-export const loadEngineResultsRequest = (
-  widgetId,
-  engineId,
-  startOffsetMs,
-  stopOffsetMs
-) => ({
-  type: LOAD_ENGINE_RESULTS,
-  payload: { engineId, startOffsetMs, stopOffsetMs },
-  meta: { widgetId }
-});
-
-export const loadEngineResultsSuccess = (
-  result,
-  { startOffsetMs, stopOffsetMs, engineId, widgetId }
-) => ({
-  type: LOAD_ENGINE_RESULTS_SUCCESS,
-  payload: result,
-  meta: { widgetId, startOffsetMs, stopOffsetMs, engineId }
-});
-
-export const loadEngineResultsFailure = ({
-  error,
-  startOffsetMs,
-  stopOffsetMs,
-  engineId,
-  widgetId
-}) => ({
-  type: LOAD_ENGINE_RESULTS_FAILURE,
-  meta: { error, startOffsetMs, stopOffsetMs, engineId, widgetId }
 });
 
 export const clearEngineResultsByEngineId = (engineId, widgetId) => ({

--- a/packages/veritone-widgets/src/redux/modules/mediaDetails/saga.js
+++ b/packages/veritone-widgets/src/redux/modules/mediaDetails/saga.js
@@ -23,11 +23,7 @@ import { modules } from 'veritone-redux-common';
 import {
   getFaceEngineAssetData,
   cancelFaceEdits,
-  fetchEngineResults as fetchFaceEngineResults,
-  FETCH_ENGINE_RESULTS,
-  ADD_DETECTED_FACE,
-  FETCH_ENGINE_RESULTS_SUCCESS,
-  FETCH_ENGINE_RESULTS_FAILURE
+  ADD_DETECTED_FACE
 } from './faceEngineOutput';
 import {
   getTranscriptEditAssetData,
@@ -36,15 +32,13 @@ import {
 const {
   auth: authModule,
   config: configModule,
-  application: applicationModule
+  application: applicationModule,
+  engineResults: engineResultsModule
 } = modules;
 
 import callGraphQLApi from '../../../shared/callGraphQLApi';
 import uploadFilesChannel from '../../../shared/uploadFilesChannel';
 import {
-  LOAD_ENGINE_RESULTS,
-  LOAD_ENGINE_RESULTS_SUCCESS,
-  LOAD_ENGINE_RESULTS_FAILURE,
   LOAD_TDO,
   UPDATE_TDO,
   UPDATE_TDO_FAILURE,
@@ -64,9 +58,6 @@ import {
   TOGGLE_EDIT_MODE,
   loadEngineCategoriesSuccess,
   loadEngineCategoriesFailure,
-  loadEngineResultsRequest,
-  loadEngineResultsSuccess,
-  loadEngineResultsFailure,
   loadTdoRequest,
   loadTdoSuccess,
   loadTdoFailure,
@@ -80,7 +71,6 @@ import {
   setEngineId,
   getTdoMetadata,
   getTdo,
-  getEngineResultRequestsByEngineId,
   toggleSaveMode,
   saveAssetDataFailure,
   createFileAssetSuccess,
@@ -91,7 +81,6 @@ import {
   isUserGeneratedTranscriptEngineId,
   toggleEditMode,
   getSelectedEngineCategory,
-  getSelectedEngineId,
   refreshEngineRunsSuccess,
   clearEngineResultsByEngineId,
   getEngineCategories,
@@ -380,66 +369,6 @@ function* updateTdoSaga(widgetId, tdoId, tdoDataToUpdate) {
   }
 
   yield put(updateTdoSuccess(widgetId, response.data.updateTDO));
-}
-
-function* loadEngineResultsSaga(
-  widgetId,
-  engineId,
-  startOffsetMs,
-  stopOffsetMs
-) {
-  const getEngineResultsQuery = `query engineResults($tdoId: ID!, $engineIds: [ID!]!, $startOffsetMs: Int, $stopOffsetMs: Int) {
-      engineResults(tdoId: $tdoId, engineIds: $engineIds, startOffsetMs: $startOffsetMs, stopOffsetMs: $stopOffsetMs) {
-        records {
-          tdoId
-          engineId
-          startOffsetMs
-          stopOffsetMs
-          jsondata
-        }
-      }
-    }`;
-
-  const config = yield select(configModule.getConfig);
-  const { apiRoot, graphQLEndpoint } = config;
-  const graphQLUrl = `${apiRoot}/${graphQLEndpoint}`;
-  const token = yield select(authModule.selectSessionToken);
-  const requestTdo = yield select(getTdo, widgetId);
-  const variables = { tdoId: requestTdo.id, engineIds: [engineId] };
-  if (startOffsetMs) {
-    variables.startOffsetMs = startOffsetMs;
-  }
-  if (stopOffsetMs) {
-    variables.stopOffsetMs = stopOffsetMs;
-  }
-  let response;
-  try {
-    response = yield call(callGraphQLApi, {
-      endpoint: graphQLUrl,
-      query: getEngineResultsQuery,
-      variables: variables,
-      token
-    });
-  } catch (error) {
-    return yield put(
-      loadEngineResultsFailure({
-        error,
-        startOffsetMs,
-        stopOffsetMs,
-        engineId,
-        widgetId
-      })
-    );
-  }
-
-  yield put(
-    loadEngineResultsSuccess(response.data.engineResults.records, {
-      startOffsetMs,
-      stopOffsetMs,
-      engineId,
-      widgetId
-    })
-  );
 }
 
 function* loadContentTemplates(widgetId) {
@@ -794,14 +723,6 @@ function* createFileAssetSaga(
     // Reset the the transcipt engine results.
     if (selectedEngineCategory.categoryType === 'transcript') {
       yield put(clearEngineResultsByEngineId(userGeneratedEngineId, widgetId));
-    } else if (selectedEngineCategory.categoryType === 'face') {
-      const selectedEngineId = yield select(getSelectedEngineId, widgetId);
-      yield put(
-        fetchFaceEngineResults({
-          selectedEngineId,
-          tdo: requestTdo
-        })
-      );
     }
     yield put(toggleEditMode(widgetId, selectedEngineCategory));
     yield put(selectEngineCategory(widgetId, updatedCategory));
@@ -1003,22 +924,6 @@ function* watchUpdateTdoContentTemplates() {
   });
 }
 
-function* watchLoadEngineResultsRequest() {
-  yield takeEvery(LOAD_ENGINE_RESULTS, function*(action) {
-    const { engineId } = action.payload;
-    let { startOffsetMs, stopOffsetMs } = action.payload;
-    const { widgetId } = action.meta;
-
-    yield call(
-      loadEngineResultsSaga,
-      widgetId,
-      engineId,
-      startOffsetMs,
-      stopOffsetMs
-    );
-  });
-}
-
 function* fetchEntities(widgetId, entityIds) {
   yield put({ type: REQUEST_ENTITIES, meta: { widgetId } });
   let entityQueries = entityIds.map((id, index) => {
@@ -1126,11 +1031,13 @@ function* fetchSchemas(widgetId, schemaIds) {
 }
 
 function* watchLoadEngineResultsComplete() {
-  yield takeEvery(LOAD_ENGINE_RESULTS_SUCCESS, function*(action) {
+  yield takeEvery(engineResultsModule.FETCH_ENGINE_RESULTS_SUCCESS, function*(
+    action
+  ) {
     let entityIds = [],
       schemaIds = [];
-    action.payload.forEach(jsonData => {
-      jsonData.jsondata.series.forEach(s => {
+    get(action, 'payload.engineResults.records', []).forEach(record => {
+      get(record, 'jsondata.series', []).forEach(s => {
         let entityId = get(s, 'object.entityId');
         if (entityId) {
           entityIds.push(entityId);
@@ -1325,8 +1232,13 @@ function* watchSetEngineId() {
   yield takeEvery(SET_SELECTED_ENGINE_ID, function*(action) {
     const selectedEngineId = action.payload;
     const { widgetId } = action.meta;
+    const selectedEngineCategory = yield select(
+      getSelectedEngineCategory,
+      widgetId
+    );
 
-    if (!selectedEngineId) {
+    // Ignore face engine results because the FaceEngineOutput handles it's own fetching
+    if (!selectedEngineId || selectedEngineCategory.categoryType === 'face') {
       return;
     }
 
@@ -1342,43 +1254,18 @@ function* watchSetEngineId() {
       stopOffsetMs = endOfTdo - startOfTdo;
     }
 
-    let engineResultRequests = yield select(
-      getEngineResultRequestsByEngineId,
-      widgetId,
-      selectedEngineId
-    );
-    let resultsInTimeBounds = engineResultRequests.filter(result => {
-      return (
-        (result.startOffsetMs >= startOffsetMs &&
-          result.startOffsetMs <= stopOffsetMs) ||
-        (result.startOffsetMs >= startOffsetMs &&
-          result.startOffsetMs <= stopOffsetMs)
-      );
-    });
-
-    // TODO: Optimize this to get all gaps not just the first
-    if (resultsInTimeBounds.length === 1) {
-      if (resultsInTimeBounds[0].startOffsetMs > startOffsetMs) {
-        stopOffsetMs = resultsInTimeBounds[0].startOffsetMs - 1;
-      } else {
-        startOffsetMs = resultsInTimeBounds[0].stopOffsetMs + 1;
-      }
-    } else if (resultsInTimeBounds.length > 1) {
-      startOffsetMs = resultsInTimeBounds[0].stopOffsetMs + 1;
-      stopOffsetMs = resultsInTimeBounds[1].startOffsetMs - 1;
-    }
-
     if (startOffsetMs > stopOffsetMs) {
       return;
     }
 
     yield put(
-      loadEngineResultsRequest(
-        widgetId,
-        selectedEngineId,
+      engineResultsModule.fetchEngineResults({
+        tdo: currentTdo,
+        engineId: selectedEngineId,
         startOffsetMs,
-        stopOffsetMs
-      )
+        stopOffsetMs,
+        ignoreUserEdited: false
+      })
     );
   });
 }
@@ -1475,6 +1362,8 @@ function* watchSaveAssetData() {
               get(asset, 'object.uri')
             );
           }
+          console.log(asset);
+          delete asset.guid;
         });
       }
       // process vtn-standard asset
@@ -1578,7 +1467,7 @@ function* watchCancelEdit() {
 }
 
 function* watchLatestFetchEngineResultsStart(widgetId) {
-  yield takeLatest([LOAD_ENGINE_RESULTS, FETCH_ENGINE_RESULTS], function*() {
+  yield takeLatest([engineResultsModule.FETCH_ENGINE_RESULTS], function*() {
     yield put(setEditButtonState(widgetId, true));
   });
 }
@@ -1586,10 +1475,8 @@ function* watchLatestFetchEngineResultsStart(widgetId) {
 function* watchLatestFetchEngineResultsEnd(widgetId) {
   yield takeLatest(
     [
-      LOAD_ENGINE_RESULTS_SUCCESS,
-      LOAD_ENGINE_RESULTS_FAILURE,
-      FETCH_ENGINE_RESULTS_SUCCESS,
-      FETCH_ENGINE_RESULTS_FAILURE
+      engineResultsModule.FETCH_ENGINE_RESULTS_SUCCESS,
+      engineResultsModule.FETCH_ENGINE_RESULTS_FAILURE
     ],
     function*() {
       yield put(setEditButtonState(widgetId, false));
@@ -1604,7 +1491,6 @@ function* onMount(id, mediaId) {
 
 export default function* root({ id, mediaId }) {
   yield all([
-    fork(watchLoadEngineResultsRequest),
     fork(watchLoadEngineResultsComplete),
     fork(watchLoadTdoRequest),
     fork(watchUpdateTdoRequest),

--- a/packages/veritone-widgets/src/redux/modules/mediaDetails/saga.js
+++ b/packages/veritone-widgets/src/redux/modules/mediaDetails/saga.js
@@ -713,7 +713,9 @@ function* createFileAssetSaga(
         tdo: requestTdo,
         engineId: selectedEngineId,
         startOffsetMs: 0,
-        stopOffsetMs: Date.parse(requestTdo.stopDateTime) - Date.parse(requestTdo.startDateTime),
+        stopOffsetMs:
+          Date.parse(requestTdo.stopDateTime) -
+          Date.parse(requestTdo.startDateTime),
         ignoreUserEdited: false
       })
     );

--- a/packages/veritone-widgets/src/redux/rootReducer.js
+++ b/packages/veritone-widgets/src/redux/rootReducer.js
@@ -37,7 +37,11 @@ const {
   config: { reducer: configReducer, namespace: configNamespace },
   auth: { reducer: authReducer, namespace: authNamespace },
   engine: { reducer: engineReducer, namespace: engineNamespace },
-  application: { reducer: applicationReducer, namespace: applicationNamespace }
+  application: { reducer: applicationReducer, namespace: applicationNamespace },
+  engineResults: {
+    reducer: engineResultsReducer,
+    namespace: engineResultsNamespace
+  }
 } = modules;
 
 import appReducer, { namespace as appNamespace } from './modules/veritoneApp';
@@ -57,6 +61,7 @@ export default function createReducer(asyncReducers) {
     [engineNamespace]: engineReducer,
     [applicationNamespace]: applicationReducer,
     [savedSearchNamespace]: savedSearchReducer,
+    [engineResultsNamespace]: engineResultsReducer,
     form: formReducer,
     player: playerReducer,
     operation: operationReducer,

--- a/packages/veritone-widgets/src/widgets/FaceEngineOutput/index.js
+++ b/packages/veritone-widgets/src/widgets/FaceEngineOutput/index.js
@@ -1,6 +1,6 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
-import { util } from 'veritone-redux-common';
+import { util, modules } from 'veritone-redux-common';
 
 import MenuItem from '@material-ui/core/MenuItem';
 import Dialog from '@material-ui/core/Dialog';
@@ -35,6 +35,8 @@ import {
 import * as faceEngineOutput from '../../redux/modules/mediaDetails/faceEngineOutput';
 import rootSaga from '../../redux/modules/mediaDetails/faceEngineOutput/saga';
 
+const { engineResults: engineResultsModule } = modules;
+
 const saga = util.reactReduxSaga.saga;
 
 @withMuiThemeProvider
@@ -45,7 +47,7 @@ const saga = util.reactReduxSaga.saga;
     entities: faceEngineOutput.getEntities(state),
     libraries: faceEngineOutput.getLibraries(state),
     entitySearchResults: faceEngineOutput.getEntitySearchResults(state),
-    isFetchingEngineResults: faceEngineOutput.isFetchingEngineResults(state),
+    isFetchingEngineResults: engineResultsModule.isFetchingEngineResults(state),
     isFetchingEntities: faceEngineOutput.isFetchingEntities(state),
     isFetchingLibraries: faceEngineOutput.isFetchingLibraries(state),
     isSearchingEntities: faceEngineOutput.isSearchingEntities(state),
@@ -55,13 +57,13 @@ const saga = util.reactReduxSaga.saga;
       state,
       selectedEngineId
     ),
-    isDisplayingUserEditedOutput: faceEngineOutput.isDisplayingUserEditedOutput(
+    isDisplayingUserEditedOutput: engineResultsModule.isDisplayingUserEditedOutput(
       state,
       selectedEngineId
     )
   }),
   {
-    fetchEngineResults: faceEngineOutput.fetchEngineResults,
+    fetchEngineResults: engineResultsModule.fetchEngineResults,
     fetchLibraries: faceEngineOutput.fetchLibraries,
     createEntity: faceEngineOutput.createEntity,
     addDetectedFace: faceEngineOutput.addDetectedFace,
@@ -197,14 +199,6 @@ class FaceEngineOutputContainer extends Component {
     ) {
       this.props.disableEdit(true);
     }
-
-    // fetch engine results when user changes engine
-    if (nextProps.selectedEngineId !== this.props.selectedEngineId) {
-      this.props.fetchEngineResults({
-        selectedEngineId: nextProps.selectedEngineId,
-        tdo: this.props.tdo
-      });
-    }
   }
 
   handleSearchEntities = searchText => {
@@ -317,9 +311,13 @@ class FaceEngineOutputContainer extends Component {
   };
 
   handleToggleEditedOutput = showUserEdited => {
+    const tdo = this.props.tdo;
     this.props.fetchEngineResults({
-      selectedEngineId: this.props.selectedEngineId,
-      tdo: this.props.tdo,
+      engineId: this.props.selectedEngineId,
+      tdo: tdo,
+      startOffsetMs: 0,
+      stopOffsetMs:
+        Date.parse(tdo.stopDateTime) - Date.parse(tdo.startDateTime),
       ignoreUserEdited: !showUserEdited
     });
   };

--- a/packages/veritone-widgets/src/widgets/MediaDetails/index.js
+++ b/packages/veritone-widgets/src/widgets/MediaDetails/index.js
@@ -57,7 +57,6 @@ import Tooltip from '@material-ui/core/Tooltip';
 import cx from 'classnames';
 import styles from './styles.scss';
 import * as mediaDetailsModule from '../../redux/modules/mediaDetails';
-import * as faceEngineOutput from '../../redux/modules/mediaDetails/faceEngineOutput';
 import widget from '../../shared/widget';
 import rootSaga from '../../redux/modules/mediaDetails/saga';
 
@@ -100,7 +99,7 @@ const programLiveImageNullState =
       mediaDetailsModule.isUserGeneratedTranscriptEngineId,
     contextMenuExtensions: applicationModule.getContextMenuExtensions(state),
     alertDialogConfig: mediaDetailsModule.getAlertDialogConfig(state, id),
-    isDisplayingUserEditedOutput: faceEngineOutput.isDisplayingUserEditedOutput(
+    isDisplayingUserEditedOutput: engineResultsModule.isDisplayingUserEditedOutput(
       state,
       mediaDetailsModule.getSelectedEngineId(state, id)
     ),
@@ -207,10 +206,12 @@ class MediaDetailsWidget extends React.Component {
               confidence: number,
               text: string
             }),
-            boundingPoly: arrayOf(shape({
-              x: number,
-              y: number
-            }))
+            boundingPoly: arrayOf(
+              shape({
+                x: number,
+                y: number
+              })
+            )
           })
         )
       })
@@ -532,7 +533,9 @@ class MediaDetailsWidget extends React.Component {
     const isFetchingEngineResults = this.props.isFetchingEngineResults;
     const hasEngineResults =
       get(selectedEngineResults, 'length') &&
-      some(selectedEngineResults, engineResult => get(engineResult, 'series.length'));
+      some(selectedEngineResults, engineResult =>
+        get(engineResult, 'series.length')
+      );
     const isRealTimeEngine =
       engineMode &&
       (engineMode.toLowerCase() === 'stream' ||

--- a/packages/veritone-widgets/src/widgets/MediaDetails/index.js
+++ b/packages/veritone-widgets/src/widgets/MediaDetails/index.js
@@ -47,7 +47,7 @@ import {
 import FaceEngineOutput from '../FaceEngineOutput';
 import TranscriptEngineOutputWidget from '../TranscriptEngineOutputWidget';
 import { modules, util } from 'veritone-redux-common';
-const { application: applicationModule } = modules;
+const { application: applicationModule, engineResults: engineResultsModule } = modules;
 import { withPropsOnChange } from 'recompose';
 import { guid } from '../../shared/util';
 import Tooltip from '@material-ui/core/Tooltip';
@@ -73,9 +73,9 @@ const programLiveImageNullState =
     engineCategories: mediaDetailsModule.getEngineCategories(state, id),
     tdo: mediaDetailsModule.getTdo(state, id),
     isLoadingTdo: mediaDetailsModule.isLoadingTdo(state, id),
-    engineResultsByEngineId: mediaDetailsModule.getEngineResultsByEngineId(
+    selectedEngineResults: engineResultsModule.engineResultsByEngineId(
       state,
-      id
+      mediaDetailsModule.getSelectedEngineId(state, id)
     ),
     selectedEngineCategory: mediaDetailsModule.getSelectedEngineCategory(
       state,
@@ -92,7 +92,8 @@ const programLiveImageNullState =
     currentMediaPlayerTime: state.player.currentTime,
     widgetError: mediaDetailsModule.getWidgetError(state, id),
     isSaveEnabled: mediaDetailsModule.isSaveEnabled(state),
-    isUserGeneratedTranscriptEngineId: mediaDetailsModule.isUserGeneratedTranscriptEngineId,
+    isUserGeneratedTranscriptEngineId:
+      mediaDetailsModule.isUserGeneratedTranscriptEngineId,
     contextMenuExtensions: applicationModule.getContextMenuExtensions(state),
     alertDialogConfig: mediaDetailsModule.getAlertDialogConfig(state, id),
     isDisplayingUserEditedOutput: faceEngineOutput.isDisplayingUserEditedOutput(
@@ -179,9 +180,17 @@ class MediaDetailsWidget extends React.Component {
       }),
       applicationId: string
     }),
-    engineResultsByEngineId: shape({
-      engineId: arrayOf(any)
-    }),
+    selectedEngineResults: arrayOf(shape({
+      sourceEngineId: string.isRequired,
+      series: arrayOf(shape({
+        startTimeMs: number.isRequired,
+        stopTimeMs: number.isRequired,
+        words: arrayOf(shape({
+          word: string.isRequired,
+          confidence: number.isRequired
+        }))
+      }))
+    })),
     selectEngineCategory: func,
     selectedEngineCategory: shape({
       id: string,
@@ -495,9 +504,7 @@ class MediaDetailsWidget extends React.Component {
     let engineStatus = get(selectedEngine, 'status');
     const engineName = get(selectedEngine, 'name');
     const engineMode = get(selectedEngine, 'mode');
-    const selectedEngineResults = this.props.engineResultsByEngineId[
-      selectedEngineId
-    ];
+    const selectedEngineResults = this.props.selectedEngineResults;
     const isFetchingEngineResults = some(
       selectedEngineResults,
       engineResult => {
@@ -618,7 +625,7 @@ class MediaDetailsWidget extends React.Component {
       engineCategories,
       selectedEngineCategory,
       selectedEngineId,
-      engineResultsByEngineId,
+      selectedEngineResults,
       isInfoPanelOpen,
       isExpandedMode,
       currentMediaPlayerTime,
@@ -1020,7 +1027,7 @@ class MediaDetailsWidget extends React.Component {
                         editMode={isEditModeEnabled}
                         mediaPlayerTimeMs={mediaPlayerTimeInMs}
                         mediaPlayerTimeIntervalMs={500}
-                        data={engineResultsByEngineId[selectedEngineId]}
+                        data={selectedEngineResults}
                         engines={selectedEngineCategory.engines}
                         onEngineChange={this.handleSelectEngine}
                         selectedEngineId={selectedEngineId}
@@ -1053,7 +1060,7 @@ class MediaDetailsWidget extends React.Component {
                   {selectedEngineCategory &&
                     selectedEngineCategory.categoryType === 'object' && (
                       <ObjectDetectionEngineOutput
-                        data={engineResultsByEngineId[selectedEngineId]}
+                        data={selectedEngineResults}
                         engines={selectedEngineCategory.engines}
                         onEngineChange={this.handleSelectEngine}
                         selectedEngineId={selectedEngineId}
@@ -1067,7 +1074,7 @@ class MediaDetailsWidget extends React.Component {
                   {selectedEngineCategory &&
                     selectedEngineCategory.categoryType === 'logo' && (
                       <LogoDetectionEngineOutput
-                        data={engineResultsByEngineId[selectedEngineId]}
+                        data={selectedEngineResults}
                         mediaPlayerTimeMs={mediaPlayerTimeInMs}
                         mediaPlayerTimeIntervalMs={500}
                         engines={selectedEngineCategory.engines}
@@ -1080,7 +1087,7 @@ class MediaDetailsWidget extends React.Component {
                   {selectedEngineCategory &&
                     selectedEngineCategory.categoryType === 'ocr' && (
                       <OCREngineOutputView
-                        data={engineResultsByEngineId[selectedEngineId]}
+                        data={selectedEngineResults}
                         className={styles.engineOuputContainer}
                         engines={selectedEngineCategory.engines}
                         onEngineChange={this.handleSelectEngine}
@@ -1093,7 +1100,7 @@ class MediaDetailsWidget extends React.Component {
                   {selectedEngineCategory &&
                     selectedEngineCategory.categoryType === 'fingerprint' && (
                       <FingerprintEngineOutput
-                        data={engineResultsByEngineId[selectedEngineId]}
+                        data={selectedEngineResults}
                         entities={entities}
                         className={styles.engineOuputContainer}
                         engines={selectedEngineCategory.engines}
@@ -1105,7 +1112,7 @@ class MediaDetailsWidget extends React.Component {
                   {selectedEngineCategory &&
                     selectedEngineCategory.categoryType === 'translate' && (
                       <TranslationEngineOutput
-                        contents={engineResultsByEngineId[selectedEngineId]}
+                        contents={selectedEngineResults}
                         onClick={this.handleUpdateMediaPlayerTime}
                         onRerunProcess={this.handleRunProcess}
                         className={styles.engineOuputContainer}
@@ -1120,7 +1127,7 @@ class MediaDetailsWidget extends React.Component {
                   {selectedEngineCategory &&
                     selectedEngineCategory.categoryType === 'sentiment' && (
                       <SentimentEngineOutput
-                        data={engineResultsByEngineId[selectedEngineId]}
+                        data={selectedEngineResults}
                         className={cx(
                           styles.engineOuputContainer,
                           styles.sentimentChartViewRoot
@@ -1136,7 +1143,7 @@ class MediaDetailsWidget extends React.Component {
                   {selectedEngineCategory &&
                     selectedEngineCategory.categoryType === 'geolocation' && (
                       <GeoEngineOutput
-                        data={engineResultsByEngineId[selectedEngineId]}
+                        data={selectedEngineResults}
                         startTimeStamp={
                           tdo && tdo.startDateTime ? tdo.startDateTime : null
                         }
@@ -1153,7 +1160,7 @@ class MediaDetailsWidget extends React.Component {
                   {selectedEngineCategory &&
                     selectedEngineCategory.categoryType === 'correlation' && (
                       <StructuredDataEngineOutput
-                        data={engineResultsByEngineId[selectedEngineId]}
+                        data={selectedEngineResults}
                         schemasById={schemasById}
                         engines={selectedEngineCategory.engines}
                         selectedEngineId={selectedEngineId}

--- a/packages/veritone-widgets/src/widgets/MediaDetails/index.js
+++ b/packages/veritone-widgets/src/widgets/MediaDetails/index.js
@@ -76,6 +76,7 @@ const programLiveImageNullState =
     engineCategories: mediaDetailsModule.getEngineCategories(state, id),
     tdo: mediaDetailsModule.getTdo(state, id),
     isLoadingTdo: mediaDetailsModule.isLoadingTdo(state, id),
+    isFetchingEngineResults: engineResultsModule.isFetchingEngineResults(state),
     selectedEngineResults: engineResultsModule.engineResultsByEngineId(
       state,
       mediaDetailsModule.getSelectedEngineId(state, id)
@@ -183,6 +184,7 @@ class MediaDetailsWidget extends React.Component {
       }),
       applicationId: string
     }),
+    isFetchingEngineResults: bool,
     selectedEngineResults: arrayOf(
       shape({
         sourceEngineId: string.isRequired,
@@ -195,7 +197,20 @@ class MediaDetailsWidget extends React.Component {
                 word: string.isRequired,
                 confidence: number.isRequired
               })
-            )
+            ),
+            object: shape({
+              label: string,
+              type: string,
+              uri: string,
+              entityId: string,
+              libraryId: string,
+              confidence: number,
+              text: string
+            }),
+            boundingPoly: arrayOf(shape({
+              x: number,
+              y: number
+            }))
           })
         )
       })
@@ -514,20 +529,10 @@ class MediaDetailsWidget extends React.Component {
     const engineName = get(selectedEngine, 'name');
     const engineMode = get(selectedEngine, 'mode');
     const selectedEngineResults = this.props.selectedEngineResults;
-    const isFetchingEngineResults = some(
-      selectedEngineResults,
-      engineResult => {
-        return engineResult && engineResult.status === 'FETCHING';
-      }
-    );
+    const isFetchingEngineResults = this.props.isFetchingEngineResults;
     const hasEngineResults =
-      selectedEngineResults &&
-      selectedEngineResults.length &&
-      some(selectedEngineResults, engineResult => {
-        return (
-          engineResult && engineResult.series && engineResult.series.length
-        );
-      });
+      get(selectedEngineResults, 'length') &&
+      some(selectedEngineResults, engineResult => get(engineResult, 'series.length'));
     const isRealTimeEngine =
       engineMode &&
       (engineMode.toLowerCase() === 'stream' ||

--- a/packages/veritone-widgets/src/widgets/MediaDetails/index.js
+++ b/packages/veritone-widgets/src/widgets/MediaDetails/index.js
@@ -47,7 +47,10 @@ import {
 import FaceEngineOutput from '../FaceEngineOutput';
 import TranscriptEngineOutputWidget from '../TranscriptEngineOutputWidget';
 import { modules, util } from 'veritone-redux-common';
-const { application: applicationModule, engineResults: engineResultsModule } = modules;
+const {
+  application: applicationModule,
+  engineResults: engineResultsModule
+} = modules;
 import { withPropsOnChange } from 'recompose';
 import { guid } from '../../shared/util';
 import Tooltip from '@material-ui/core/Tooltip';
@@ -180,17 +183,23 @@ class MediaDetailsWidget extends React.Component {
       }),
       applicationId: string
     }),
-    selectedEngineResults: arrayOf(shape({
-      sourceEngineId: string.isRequired,
-      series: arrayOf(shape({
-        startTimeMs: number.isRequired,
-        stopTimeMs: number.isRequired,
-        words: arrayOf(shape({
-          word: string.isRequired,
-          confidence: number.isRequired
-        }))
-      }))
-    })),
+    selectedEngineResults: arrayOf(
+      shape({
+        sourceEngineId: string.isRequired,
+        series: arrayOf(
+          shape({
+            startTimeMs: number.isRequired,
+            stopTimeMs: number.isRequired,
+            words: arrayOf(
+              shape({
+                word: string.isRequired,
+                confidence: number.isRequired
+              })
+            )
+          })
+        )
+      })
+    ),
     selectEngineCategory: func,
     selectedEngineCategory: shape({
       id: string,


### PR DESCRIPTION
I moved the redux code for engine results to have it's own reducer and store in redux-common. I also refactored all the components where we are using engine results (MediaDetail widget, FaceEngineOutput smart component) to use the new redux store rather than duplicating code in multiple places.

