### PR TITLE
Do not hardcode z-index in the FullScreenDialog

### DIFF
--- a/packages/veritone-react-common/src/components/FullScreenDialog/styles.scss
+++ b/packages/veritone-react-common/src/components/FullScreenDialog/styles.scss
@@ -4,7 +4,6 @@
   left: 0;
   right: 0;
   bottom: 0;
-  z-index: 950;
   background: white;
   opacity: 0;
   height: 0;

--- a/packages/veritone-react-common/src/components/SourceManagement/SourceManagementForm/index.js
+++ b/packages/veritone-react-common/src/components/SourceManagement/SourceManagementForm/index.js
@@ -189,7 +189,7 @@ export default class SourceManagementForm extends React.Component {
     const { activeTab } = this.state;
 
     return (
-      <FullScreenDialog open={this.state.openDialog}>
+      <FullScreenDialog open={this.state.openDialog} className={styles['sm-fullscreen-dialog']}>
         <div className={styles['sm-form-wrapper']}>
           <ModalHeader
             title={

--- a/packages/veritone-react-common/src/components/SourceManagement/SourceManagementForm/styles.scss
+++ b/packages/veritone-react-common/src/components/SourceManagement/SourceManagementForm/styles.scss
@@ -1,6 +1,10 @@
 @import 'src/styles/modules/variables';
 @import 'src/styles/modules/muiTypography';
 
+.sm-fullscreen-dialog {
+  z-index: 950;
+}
+
 .source-config-wrapper {
   width: 50%;
 }

--- a/packages/veritone-widgets/src/widgets/MediaDetails/styles.scss
+++ b/packages/veritone-widgets/src/widgets/MediaDetails/styles.scss
@@ -17,7 +17,6 @@
   display: flex;
   flex-direction: column;
   flex: auto;
-  z-index: auto;
 
   .headerMenuItem {
     color: $dark-black !important;


### PR DESCRIPTION
instead, allow component users to set it.
Run Process dialog has z-index:80, MDP - 50. SourceManagementForm - 950.