### PR TITLE
Feature/vtn 8310 autorefresh engine status and results

### DIFF
--- a/packages/veritone-widgets/src/redux/modules/mediaDetails/index.js
+++ b/packages/veritone-widgets/src/redux/modules/mediaDetails/index.js
@@ -189,7 +189,6 @@ export default createReducer(defaultState, {
     }
   ) {
     const errorMessage = get(error, 'message', error);
-    console.log('Failed to load tdo. Disable Spinner. Show error.');
     return {
       ...state,
       [widgetId]: {

--- a/packages/veritone-widgets/src/redux/modules/mediaDetails/saga.js
+++ b/packages/veritone-widgets/src/redux/modules/mediaDetails/saga.js
@@ -137,8 +137,6 @@ const engineRunsQueryClause = `engineRuns(limit: 1000) {
   `;
 
 function* finishLoadEngineCategories(widgetId, result, { error }) {
-  console.log('finishLoadEngineCategories');
-  console.log(result);
   if (error) {
     return yield put(loadEngineCategoriesFailure(widgetId, { error }));
   }

--- a/packages/veritone-widgets/src/widgets/MediaDetails/index.js
+++ b/packages/veritone-widgets/src/widgets/MediaDetails/index.js
@@ -149,6 +149,7 @@ class MediaDetailsWidget extends React.Component {
       features: objectOf(any),
       applicationIds: arrayOf(string)
     }),
+    refreshIntervalMs: number,
     onRunProcess: func,
     onClose: func,
     updateTdoRequest: func,

--- a/packages/veritone-widgets/src/widgets/MediaDetails/index.js
+++ b/packages/veritone-widgets/src/widgets/MediaDetails/index.js
@@ -149,6 +149,8 @@ class MediaDetailsWidget extends React.Component {
       features: objectOf(any),
       applicationIds: arrayOf(string)
     }),
+    // property to configure experimental autorefresh in saga
+    // eslint-disable-next-line react/no-unused-prop-types
     refreshIntervalMs: number,
     onRunProcess: func,
     onClose: func,
@@ -567,6 +569,15 @@ class MediaDetailsWidget extends React.Component {
     );
   };
 
+  isSelectedEngineCompleted = () => {
+    const selectedEngineId = this.props.selectedEngineId;
+    const engines = get(this.props.selectedEngineCategory, 'engines');
+    const selectedEngine = find(engines, {
+      id: selectedEngineId
+    });
+    return get(selectedEngine, 'status') === 'complete';
+  };
+
   buildEngineNullStateComponent = () => {
     const selectedEngineId = this.props.selectedEngineId;
     const engines = get(this.props.selectedEngineCategory, 'engines');
@@ -658,7 +669,11 @@ class MediaDetailsWidget extends React.Component {
   };
 
   showEditButton = () => {
-    if (!this.isEditableEngineResults() || !this.hasSelectedEngineResults()) {
+    if (
+      !this.isEditableEngineResults() ||
+      !this.hasSelectedEngineResults() ||
+      !this.isSelectedEngineCompleted()
+    ) {
       return false;
     }
     return true;

--- a/packages/veritone-widgets/src/widgets/MediaDetails/index.js
+++ b/packages/veritone-widgets/src/widgets/MediaDetails/index.js
@@ -701,8 +701,12 @@ class MediaDetailsWidget extends React.Component {
 
   isRealTimeEngine(engine) {
     const engineMode = get(engine, 'mode');
-    return engineMode && (engineMode.toLowerCase() === 'stream' || engineMode.toLowerCase() === 'chunk');
-  };
+    return (
+      engineMode &&
+      (engineMode.toLowerCase() === 'stream' ||
+        engineMode.toLowerCase() === 'chunk')
+    );
+  }
 
   closeTranscriptBulkEditSnack = () => {
     this.props.setShowTranscriptBulkEditSnackState(this.props.id, false);


### PR DESCRIPTION
Kick in refreshing engine runs at intervals, and engine results when selected engine status has changed. By default refresh is disabled - to enable pass ms value to the widget