### PR TITLE
Only display closed caption formats when feature flag enabled

### DIFF
--- a/packages/veritone-widgets/src/widgets/MediaDetails/MoreMenuItems/ExportMenuItem.js
+++ b/packages/veritone-widgets/src/widgets/MediaDetails/MoreMenuItems/ExportMenuItem.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
-import { shape, arrayOf, string, func } from 'prop-types';
-import { includes, without } from 'lodash';
+import { shape, arrayOf, string, func, bool } from 'prop-types';
+import { includes, without, find } from 'lodash';
 import { Manager, Target, Popper } from 'react-popper';
 import styles from './styles.scss';
 import MenuList from '@material-ui/core/MenuList';
@@ -22,7 +22,12 @@ class ExportMenuItem extends Component {
         label: string.isRequired
       })
     ).isRequired,
-    onCloseMoreMenu: func
+    onCloseMoreMenu: func,
+    exportClosedCaptionsEnabled: bool
+  };
+
+  static defaultProps = {
+    exportClosedCaptionsEnabled: false
   };
 
   state = {
@@ -58,8 +63,17 @@ class ExportMenuItem extends Component {
   };
 
   render() {
-    const { label, onMoreClicked, categoryExportFormats } = this.props;
+    const {
+      label,
+      onMoreClicked,
+      categoryExportFormats,
+      exportClosedCaptionsEnabled
+    } = this.props;
     const { showSubMenu, selectedFormats } = this.state;
+
+    const hasSubtitleFormats = !!find(categoryExportFormats, format =>
+      includes(format.types, 'subtitle')
+    );
 
     return (
       <Manager>
@@ -78,9 +92,18 @@ class ExportMenuItem extends Component {
               <Paper className={styles.exportFormatMenu}>
                 <MenuList>
                   <ListItem className={styles.subMenuTitle} disableGutters>
-                    TRANSCRIPTION & SUBTITLES
+                    TRANSCRIPTION{hasSubtitleFormats &&
+                    exportClosedCaptionsEnabled
+                      ? ' & SUBTITLES'
+                      : ''}
                   </ListItem>
                   {categoryExportFormats.map(format => {
+                    if (
+                      !exportClosedCaptionsEnabled &&
+                      includes(format.types, 'subtitle')
+                    ) {
+                      return null;
+                    }
                     return (
                       <MenuItem
                         key={`format-menu-item-${format.format}`}

--- a/packages/veritone-widgets/src/widgets/MediaDetails/index.js
+++ b/packages/veritone-widgets/src/widgets/MediaDetails/index.js
@@ -118,7 +118,11 @@ const programLiveImageNullState =
       id
     ),
     categoryExportFormats: mediaDetailsModule.categoryExportFormats(state, id),
-    betaFlagEnabled: userModule.hasFeature(state, 'beta')
+    betaFlagEnabled: userModule.hasFeature(state, 'beta'),
+    exportClosedCaptionsEnabled: userModule.hasFeature(
+      state,
+      'exportClosedCaptions'
+    )
   }),
   {
     initializeWidget: mediaDetailsModule.initializeWidget,
@@ -350,7 +354,8 @@ class MediaDetailsWidget extends React.Component {
     ),
     createQuickExport: func.isRequired,
     betaFlagEnabled: bool.isRequired,
-    onExport: func
+    onExport: func,
+    exportClosedCaptionsEnabled: bool
   };
 
   static contextTypes = {
@@ -854,7 +859,8 @@ class MediaDetailsWidget extends React.Component {
       alertDialogConfig,
       categoryExportFormats,
       betaFlagEnabled,
-      onExport
+      onExport,
+      exportClosedCaptionsEnabled
     } = this.props;
 
     const { isMenuOpen } = this.state;
@@ -887,6 +893,7 @@ class MediaDetailsWidget extends React.Component {
           onExportClicked={this.handleExportClicked}
           onMoreClicked={this.openEngineOutputExport}
           categoryExportFormats={categoryExportFormats}
+          exportClosedCaptionsEnabled={exportClosedCaptionsEnabled}
         />
       );
     }


### PR DESCRIPTION
I added a new prop to ExportMenuItem component to enable closed caption formats in the quick export menu.