### PR TITLE
Bounding poly overlay styling

### DIFF
--- a/packages/veritone-react-common/src/components/BoundingPolyOverlay/Overlay.js
+++ b/packages/veritone-react-common/src/components/BoundingPolyOverlay/Overlay.js
@@ -49,10 +49,9 @@ export default class Overlay extends React.Component {
       height: number.isRequired
     }).isRequired,
     wrapperStyles: objectOf(any),
+    stylesByObjectType: objectOf(objectOf(any)),
     toolBarOffset: number,
-    overlayBackgroundColor: string,
-    overlayBorderStyle: string,
-    overlayBackgroundBlendMode: string,
+    stagedBoundingBoxStyles: objectOf(any),
     onAddBoundingBox: func.isRequired,
     onDeleteBoundingBox: func.isRequired,
     onChangeBoundingBox: func.isRequired,
@@ -60,6 +59,9 @@ export default class Overlay extends React.Component {
       shape({
         // unique ID
         id: string.isRequired,
+        // optional type for styles + future stuff maybe
+        // (corresponds to props.stylesByObjectType)
+        overlayObjectType: string,
         // vertices
         boundingPoly: arrayOf(
           shape({
@@ -83,9 +85,8 @@ export default class Overlay extends React.Component {
     addOnly: false,
     initialBoundingBoxPolys: [],
     toolBarOffset: 0,
-    overlayBackgroundColor: '#FF6464',
-    overlayBackgroundBlendMode: 'hard-light',
-    overlayBorderStyle: '1px solid #fff'
+    stagedBoundingBoxStyles: {},
+    stylesByObjectType: {}
   };
 
   state = {
@@ -111,13 +112,14 @@ export default class Overlay extends React.Component {
   /* eslint-disable-next-line react/sort-comp */
   static mapPolysToInternalFormat = memoize(
     (polys, width, height) =>
-      polys.map(({ boundingPoly, id }) => ({
+      polys.map(({ boundingPoly, id, ...rest }) => ({
         boundingPoly: percentagePolyToPixelXYWidthHeight(
           boundingPoly,
           width,
           height
         ),
-        id
+        id,
+        ...rest
       })),
     isEqual
   );
@@ -170,12 +172,12 @@ export default class Overlay extends React.Component {
     });
 
     this.props.onChangeBoundingBox({
+      ...this.state.boundingBoxPositions[focusedIndex],
       boundingPoly: pixelXYWidthHeightToPercentagePoly(
         this.state.boundingBoxPositions[focusedIndex].boundingPoly,
         this.props.overlayPositioningContext.width,
         this.props.overlayPositioningContext.height
-      ),
-      id: focusedId
+      )
     });
 
     this.setState({
@@ -207,12 +209,12 @@ export default class Overlay extends React.Component {
     };
 
     this.props.onChangeBoundingBox({
+      ...this.state.boundingBoxPositions[focusedIndex],
       boundingPoly: pixelXYWidthHeightToPercentagePoly(
         draggedObject,
         this.props.overlayPositioningContext.width,
         this.props.overlayPositioningContext.height
-      ),
-      id: focusedId
+      )
     });
 
     this.setState({
@@ -379,11 +381,10 @@ export default class Overlay extends React.Component {
       !this.state.userActingOnBoundingBox &&
       !this.state.userMinimizedConfirmMenu;
 
-    const boundingBoxStyles = {
-      border: this.props.overlayBorderStyle,
-      backgroundColor: this.props.overlayBackgroundColor,
-      mixBlendMode: this.props.overlayBackgroundBlendMode,
-      willChange: 'left, top, width, height' // this seems to fix some rendering jank
+    const boundingBoxCommonStyles = {
+      // this seems to fix some rendering jank
+      // (half of overlay would not render sometimes)
+      willChange: 'left, top, width, height'
     };
 
     return (
@@ -400,7 +401,11 @@ export default class Overlay extends React.Component {
         }}
       >
         {this.state.boundingBoxPositions.map(
-          ({ id, boundingPoly: { x, y, width, height } }) => (
+          ({
+            id,
+            overlayObjectType,
+            boundingPoly: { x, y, width, height }
+          }) => (
             <RndBox
               key={id}
               extendsProps={{
@@ -408,7 +413,11 @@ export default class Overlay extends React.Component {
                 onClick: this.handleClickBox
               }}
               style={{
-                ...boundingBoxStyles,
+                backgroundColor: '#FF6464',
+                mixBlendMode: 'hard-light',
+                border: '1px solid #fff',
+                ...boundingBoxCommonStyles,
+                ...this.props.stylesByObjectType[overlayObjectType],
                 // do not let this box interfere with mouse events as we draw out
                 // the initial bounding box
                 pointerEvents:
@@ -440,7 +449,12 @@ export default class Overlay extends React.Component {
           !this.props.readOnly && (
             <RndBox
               style={{
-                ...boundingBoxStyles, // do not let this box interfere with mouse events as we draw it out
+                backgroundColor: '#FF6464',
+                mixBlendMode: 'hard-light',
+                border: '1px solid #fff',
+                ...boundingBoxCommonStyles,
+                ...this.props.stagedBoundingBoxStyles,
+                // do not let this box interfere with mouse events as we draw it out
                 pointerEvents: this.state.drawingInitialBoundingBox
                   ? 'none'
                   : 'auto'

--- a/packages/veritone-react-common/src/components/BoundingPolyOverlay/Overlay.js
+++ b/packages/veritone-react-common/src/components/BoundingPolyOverlay/Overlay.js
@@ -413,8 +413,7 @@ export default class Overlay extends React.Component {
                 onClick: this.handleClickBox
               }}
               style={{
-                backgroundColor: '#FF6464',
-                mixBlendMode: 'hard-light',
+                backgroundColor: 'rgba(255,100,100, .5)',
                 border: '1px solid #fff',
                 ...boundingBoxCommonStyles,
                 ...this.props.stylesByObjectType[overlayObjectType],
@@ -449,8 +448,7 @@ export default class Overlay extends React.Component {
           !this.props.readOnly && (
             <RndBox
               style={{
-                backgroundColor: '#FF6464',
-                mixBlendMode: 'hard-light',
+                backgroundColor: 'rgba(255,100,100, .5)',
                 border: '1px solid #fff',
                 ...boundingBoxCommonStyles,
                 ...this.props.stagedBoundingBoxStyles,

--- a/packages/veritone-react-common/src/components/BoundingPolyOverlay/Overlay.js
+++ b/packages/veritone-react-common/src/components/BoundingPolyOverlay/Overlay.js
@@ -49,9 +49,10 @@ export default class Overlay extends React.Component {
       height: number.isRequired
     }).isRequired,
     wrapperStyles: objectOf(any),
+    defaultBoundingBoxStyles: objectOf(any),
+    stagedBoundingBoxStyles: objectOf(any),
     stylesByObjectType: objectOf(objectOf(any)),
     toolBarOffset: number,
-    stagedBoundingBoxStyles: objectOf(any),
     onAddBoundingBox: func.isRequired,
     onDeleteBoundingBox: func.isRequired,
     onChangeBoundingBox: func.isRequired,
@@ -86,7 +87,11 @@ export default class Overlay extends React.Component {
     initialBoundingBoxPolys: [],
     toolBarOffset: 0,
     stagedBoundingBoxStyles: {},
-    stylesByObjectType: {}
+    stylesByObjectType: {},
+    defaultBoundingBoxStyles: {
+      backgroundColor: 'rgba(255,100,100, .5)',
+      border: '1px solid #fff'
+    }
   };
 
   state = {
@@ -112,13 +117,12 @@ export default class Overlay extends React.Component {
   /* eslint-disable-next-line react/sort-comp */
   static mapPolysToInternalFormat = memoize(
     (polys, width, height) =>
-      polys.map(({ boundingPoly, id, ...rest }) => ({
+      polys.map(({ boundingPoly, ...rest }) => ({
         boundingPoly: percentagePolyToPixelXYWidthHeight(
           boundingPoly,
           width,
           height
         ),
-        id,
         ...rest
       })),
     isEqual
@@ -413,9 +417,8 @@ export default class Overlay extends React.Component {
                 onClick: this.handleClickBox
               }}
               style={{
-                backgroundColor: 'rgba(255,100,100, .5)',
-                border: '1px solid #fff',
                 ...boundingBoxCommonStyles,
+                ...this.props.defaultBoundingBoxStyles,
                 ...this.props.stylesByObjectType[overlayObjectType],
                 // do not let this box interfere with mouse events as we draw out
                 // the initial bounding box
@@ -448,9 +451,8 @@ export default class Overlay extends React.Component {
           !this.props.readOnly && (
             <RndBox
               style={{
-                backgroundColor: 'rgba(255,100,100, .5)',
-                border: '1px solid #fff',
                 ...boundingBoxCommonStyles,
+                ...this.props.defaultBoundingBoxStyles,
                 ...this.props.stagedBoundingBoxStyles,
                 // do not let this box interfere with mouse events as we draw it out
                 pointerEvents: this.state.drawingInitialBoundingBox

--- a/packages/veritone-react-common/src/components/BoundingPolyOverlay/story.js
+++ b/packages/veritone-react-common/src/components/BoundingPolyOverlay/story.js
@@ -162,12 +162,11 @@ storiesOf('BoundingPolyOverlay', module).add('Base', () => {
   const contentWidth = number('content width', 320);
   const contentHeight = number('content height', 240);
   const matteSize = number('matte size', 100);
-  const overlayBackgroundColor = text('Overlay background color', '#FF6464');
-  const overlayBorderStyle = text('Overlay border style', '1px solid #fff');
-  const overlayBackgroundBlendMode = text(
-    'Overlay background blend mode',
-    'hard-light'
+  const overlayBackgroundColor = text(
+    'Overlay background color',
+    'rgba(255, 100, 100, 0.5)'
   );
+  const overlayBorderStyle = text('Overlay border style', '1px solid #fff');
   const readOnly = boolean('Read only mode', false);
   const addOnly = boolean('Add only mode', false);
   const autoCommit = boolean('Auto commit mode', false);
@@ -185,18 +184,17 @@ storiesOf('BoundingPolyOverlay', module).add('Base', () => {
         matteSize={matteSize}
         stagedBoundingBoxStyles={{
           backgroundColor: overlayBackgroundColor,
-          border: overlayBorderStyle,
-          mixBlendMode: overlayBackgroundBlendMode
+          border: overlayBorderStyle
         }}
         stylesByObjectType={{
           a: {
-            backgroundColor: 'blue'
+            backgroundColor: 'rgba(40, 95, 255, 0.5)'
           },
           b: {
-            backgroundColor: 'green'
+            backgroundColor: 'rgba(80, 185, 60, 0.5)'
           },
           c: {
-            backgroundColor: 'orange'
+            backgroundColor: 'rgba(255, 140, 40, 0.5)'
           }
         }}
         readOnly={readOnly}

--- a/packages/veritone-react-common/src/components/BoundingPolyOverlay/story.js
+++ b/packages/veritone-react-common/src/components/BoundingPolyOverlay/story.js
@@ -9,12 +9,15 @@ import { guid } from 'helpers/guid';
 import OverlayPositioningProvider from './OverlayPositioningProvider';
 import Overlay from './Overlay';
 
+const types = ['a', 'b', 'c'];
+
 function randomPolyBox() {
   const rand = faker.random.number;
   const options = { min: 0, max: 1, precision: 0.0001 };
 
   return {
     id: guid(),
+    overlayObjectType: faker.random.arrayElement(types),
     boundingPoly: Array(4)
       .fill()
       .map(() => ({
@@ -55,7 +58,8 @@ class Story extends React.Component {
         ...state.boundingBoxes,
         {
           ...newBox,
-          id: guid()
+          id: guid(),
+          overlayObjectType: faker.random.arrayElement(types)
         }
       ]
     }));
@@ -112,9 +116,8 @@ class Story extends React.Component {
             onAddBoundingBox={this.handleAddBoundingBox}
             onDeleteBoundingBox={this.handleDeleteBoundingBox}
             onChangeBoundingBox={this.handleChangeBoundingBox}
-            overlayBackgroundColor={this.props.overlayBackgroundColor}
-            overlayBorderStyle={this.props.overlayBorderStyle}
-            overlayBackgroundBlendMode={this.props.overlayBackgroundBlendMode}
+            stylesByObjectType={this.props.stylesByObjectType}
+            stagedBoundingBoxStyles={this.props.stagedBoundingBoxStyles}
             initialBoundingBoxPolys={this.state.boundingBoxes}
             actionMenuItems={this.actionMenuItems}
             readOnly={this.props.readOnly}
@@ -180,9 +183,22 @@ storiesOf('BoundingPolyOverlay', module).add('Base', () => {
         contentWidth={contentWidth}
         matteType={matteType}
         matteSize={matteSize}
-        overlayBackgroundColor={overlayBackgroundColor}
-        overlayBorderStyle={overlayBorderStyle}
-        overlayBackgroundBlendMode={overlayBackgroundBlendMode}
+        stagedBoundingBoxStyles={{
+          backgroundColor: overlayBackgroundColor,
+          border: overlayBorderStyle,
+          mixBlendMode: overlayBackgroundBlendMode
+        }}
+        stylesByObjectType={{
+          a: {
+            backgroundColor: 'blue'
+          },
+          b: {
+            backgroundColor: 'green'
+          },
+          c: {
+            backgroundColor: 'orange'
+          }
+        }}
         readOnly={readOnly}
         addOnly={addOnly}
         autoCommit={autoCommit}

--- a/packages/veritone-widgets/src/widgets/MediaPlayer/index.js
+++ b/packages/veritone-widgets/src/widgets/MediaPlayer/index.js
@@ -15,7 +15,10 @@ import {
 import { connect } from 'react-redux';
 import { Player, ControlBar, BigPlayButton } from 'video-react';
 
-import { BoundingPolyOverlay, OverlayPositioningProvider } from 'veritone-react-common';
+import {
+  BoundingPolyOverlay,
+  OverlayPositioningProvider
+} from 'veritone-react-common';
 import VideoSource from './VideoSource';
 import { getPolysForTime } from './helpers';
 
@@ -44,6 +47,7 @@ class MediaPlayerComponent extends React.Component {
         stopTimeMs: number.isRequired,
         object: shape({
           id: string.isRequired,
+          overlayObjectType: string,
           boundingPoly: arrayOf(
             shape({ x: number.isRequired, y: number.isRequired })
           ).isRequired
@@ -53,7 +57,10 @@ class MediaPlayerComponent extends React.Component {
     onAddBoundingBox: func,
     onDeleteBoundingBox: func,
     onChangeBoundingBox: func,
-    overlayBorderStyle: string,
+
+    stagedBoundingBoxStyles: objectOf(any),
+    stylesByObjectType: objectOf(objectOf(any)),
+
     actionMenuItems: arrayOf(
       shape({
         label: string.isRequired,
@@ -86,7 +93,7 @@ class MediaPlayerComponent extends React.Component {
     fluid: true,
     onAddBoundingBox: noop,
     onDeleteBoundingBox: noop,
-    onChangeBoundingBox: noop,
+    onChangeBoundingBox: noop
   };
 
   handleAddBoundingBox = newBox => {
@@ -113,8 +120,6 @@ class MediaPlayerComponent extends React.Component {
             onAddBoundingBox={this.handleAddBoundingBox}
             onDeleteBoundingBox={this.props.onDeleteBoundingBox}
             onChangeBoundingBox={this.props.onChangeBoundingBox}
-            overlayBackgroundColor="rgba(238, 110, 105, 0.5)"
-            overlayBorderStyle={this.props.overlayBorderStyle}
             initialBoundingBoxPolys={
               this.props.boundingPolySeries ? currentPolys : undefined
             }
@@ -122,6 +127,8 @@ class MediaPlayerComponent extends React.Component {
             addOnly={this.props.addOnly}
             readOnly={this.props.readOnly || !this.props.paused}
             autoCommit={this.props.autoCommit}
+            stagedBoundingBoxStyles={props.stagedBoundingBoxStyles}
+            stylesByObjectType={props.stylesByObjectType}
           />
         )}
         <Player

--- a/packages/veritone-widgets/src/widgets/MediaPlayer/index.js
+++ b/packages/veritone-widgets/src/widgets/MediaPlayer/index.js
@@ -58,6 +58,7 @@ class MediaPlayerComponent extends React.Component {
     onDeleteBoundingBox: func,
     onChangeBoundingBox: func,
 
+    defaultBoundingBoxStyles: objectOf(any),
     stagedBoundingBoxStyles: objectOf(any),
     stylesByObjectType: objectOf(objectOf(any)),
 
@@ -129,6 +130,7 @@ class MediaPlayerComponent extends React.Component {
             autoCommit={this.props.autoCommit}
             stagedBoundingBoxStyles={props.stagedBoundingBoxStyles}
             stylesByObjectType={props.stylesByObjectType}
+            defaultBoundingBoxStyles={props.defaultBoundingBoxStyles}
           />
         )}
         <Player

--- a/packages/veritone-widgets/src/widgets/MediaPlayer/story.js
+++ b/packages/veritone-widgets/src/widgets/MediaPlayer/story.js
@@ -24,6 +24,7 @@ const timeSeries = [
     startTimeMs: 0,
     object: {
       id: guid(),
+      overlayObjectType: 'a',
       boundingPoly: randomPolyBox()
     },
     stopTimeMs: 5000
@@ -32,6 +33,7 @@ const timeSeries = [
     startTimeMs: 2000,
     object: {
       id: guid(),
+      overlayObjectType: 'a',
       boundingPoly: randomPolyBox()
     },
     stopTimeMs: 8000
@@ -40,6 +42,7 @@ const timeSeries = [
     startTimeMs: 8000,
     object: {
       id: guid(),
+      overlayObjectType: 'b',
       boundingPoly: randomPolyBox()
     },
     stopTimeMs: 12000
@@ -48,6 +51,7 @@ const timeSeries = [
     startTimeMs: 9000,
     object: {
       id: guid(),
+      overlayObjectType: 'c',
       boundingPoly: randomPolyBox()
     },
     stopTimeMs: 14000
@@ -56,6 +60,7 @@ const timeSeries = [
     startTimeMs: 10000,
     object: {
       id: guid(),
+      overlayObjectType: 'a',
       boundingPoly: randomPolyBox()
     },
     stopTimeMs: 14000
@@ -64,6 +69,7 @@ const timeSeries = [
     startTimeMs: 17000,
     object: {
       id: guid(),
+      overlayObjectType: 'c',
       boundingPoly: randomPolyBox()
     },
     stopTimeMs: 19000
@@ -72,6 +78,7 @@ const timeSeries = [
     startTimeMs: 20000,
     object: {
       id: guid(),
+      overlayObjectType: 'b',
       boundingPoly: randomPolyBox()
     },
     stopTimeMs: 25000
@@ -80,6 +87,7 @@ const timeSeries = [
     startTimeMs: 21000,
     object: {
       id: guid(),
+      overlayObjectType: 'b',
       boundingPoly: randomPolyBox()
     },
     stopTimeMs: 24000
@@ -88,6 +96,7 @@ const timeSeries = [
     startTimeMs: 21000,
     object: {
       id: guid(),
+      overlayObjectType: 'a',
       boundingPoly: randomPolyBox()
     },
     stopTimeMs: 25000
@@ -96,6 +105,7 @@ const timeSeries = [
     startTimeMs: 25000,
     object: {
       id: guid(),
+      overlayObjectType: 'c',
       boundingPoly: randomPolyBox()
     },
     stopTimeMs: 30000
@@ -104,6 +114,7 @@ const timeSeries = [
     startTimeMs: 28000,
     object: {
       id: guid(),
+      overlayObjectType: 'a',
       boundingPoly: randomPolyBox()
     },
     stopTimeMs: 30000
@@ -220,6 +231,17 @@ class Story extends React.Component {
           onAddBoundingBox={this.handleAddBoundingBox}
           onDeleteBoundingBox={this.handleDeleteBoundingBox}
           onChangeBoundingBox={this.handleChangeBoundingBox}
+          stylesByObjectType={{
+            a: {
+              backgroundColor: 'rgba(40, 95, 255, 0.5)'
+            },
+            b: {
+              backgroundColor: 'rgba(80, 185, 60, 0.5)'
+            },
+            c: {
+              backgroundColor: 'rgba(255, 140, 40, 0.5)'
+            }
+          }}
           ref={this.playerRef}
         />
         <DefaultControlBar playerRef={this.playerRef} />


### PR DESCRIPTION
given a `overlayObjectType` in the bounding poly data structure, we can now apply styles to bounding boxes by type (and maybe future stuff, for example custom selection/editing behavior for different box types)

also removes mixBlendMode stuff in favor of simple rgba opacity since mixblend wasn't working in the video component. Can still be added in custom styles, just isn't first-class anymore.