### PR TITLE
Feature/extend sdo table merge to master

### DIFF
--- a/packages/veritone-react-common/src/components/DataTable/index.js
+++ b/packages/veritone-react-common/src/components/DataTable/index.js
@@ -58,7 +58,6 @@ class _Table extends React.Component {
   render() {
     const restProps = omit(this.props, [
       'onShowCellRange',
-      'focusedRow',
       'renderFocusedRowDetails'
     ]);
 
@@ -76,7 +75,9 @@ class _Table extends React.Component {
         }}
         component="div"
       >
-        {isNumber(this.props.focusedRow) && this.props.rowCount > 0 ? (
+        {isNumber(this.props.focusedRow) &&
+        this.props.rowCount > 0 &&
+        this.props.renderFocusedRowDetails ? (
           <SplitTableContainer
             {...restProps}
             focusedRow={this.props.focusedRow}
@@ -270,6 +271,7 @@ const TableBody = ({
   rowRangeEnd,
   rowGetter,
   rowHeight,
+  focusedRow,
   onCellClick,
   ...rest
 }) => {
@@ -279,7 +281,12 @@ const TableBody = ({
         ? range(rowRangeStart, rowRangeEnd)
         : range(rowRangeEnd)
       ).map(r => (
-        <TableRow key={r} style={{ height: rowHeight }} hover>
+        <TableRow
+          key={r}
+          style={{ height: rowHeight }}
+          hover
+          selected={r == focusedRow}
+        >
           {injectInto(children, {
             data: rowGetter(r),
             row: r,
@@ -295,6 +302,7 @@ TableBody.propTypes = {
   rowRangeEnd: number,
   rowHeight: number,
   rowGetter: func,
+  focusedRow: number,
   children: node,
   onCellClick: func
 };

--- a/packages/veritone-react-common/src/components/SDOTable/index.js
+++ b/packages/veritone-react-common/src/components/SDOTable/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { arrayOf, object, objectOf, bool } from 'prop-types';
+import { arrayOf, object, objectOf, bool, number, func } from 'prop-types';
 import { Table, PaginatedTable, Column } from 'components/DataTable';
 import { map, startCase, partial, omit } from 'lodash';
 import DotDotDot from 'react-dotdotdot';
@@ -9,7 +9,10 @@ export default class SDOTable extends React.Component {
   static propTypes = {
     data: arrayOf(object).isRequired,
     schema: objectOf(object).isRequired,
-    paginate: bool
+    paginate: bool,
+    onCellClick: func,
+    focusedRow: number,
+    renderFocusedRowDetails: func
   };
 
   static defaultProps = {
@@ -37,11 +40,45 @@ export default class SDOTable extends React.Component {
     return <DotDotDot clamp={2}>{formattedData}</DotDotDot>;
   };
 
+  buildColumnsForObjectTypeProperty = (propDetails, propKey) => {
+    const allProps = {};
+    this.flattenAllObjectTypeProperties(allProps, propDetails, propKey);
+    return map(allProps, (nestedPropDetails, nestedProp) => (
+      <Column
+        dataKey={nestedProp}
+        header={nestedPropDetails.title || startCase(nestedProp)}
+        cellRenderer={partial(
+          this.renderCell,
+          partial.placeholder,
+          nestedPropDetails.type
+        )}
+        key={nestedPropDetails.$id}
+      />
+    ));
+  };
+
+  flattenAllObjectTypeProperties = (allProps, propDetails, propKey) => {
+    for (let nestedPropKey in propDetails.properties) {
+      if (propDetails.properties[nestedPropKey].type === 'object') {
+        this.flattenAllObjectTypeProperties(
+          allProps,
+          propDetails.properties[nestedPropKey],
+          `${propKey}.${nestedPropKey}`
+        );
+      } else {
+        allProps[`${propKey}.${nestedPropKey}`] =
+          propDetails.properties[nestedPropKey];
+      }
+    }
+  };
+
   render() {
     const tableProps = omit(this.props, ['data', 'schema', 'paginate']);
-
     const TableComponent = this.props.paginate ? PaginatedTable : Table;
     const tableColumns = map(this.props.schema, (propDetails, prop) => {
+      if (propDetails.type === 'object') {
+        return this.buildColumnsForObjectTypeProperty(propDetails, prop);
+      }
       return (
         <Column
           dataKey={prop}
@@ -61,6 +98,8 @@ export default class SDOTable extends React.Component {
         {...tableProps}
         rowGetter={this.getRowData}
         rowCount={this.props.data.length}
+        focusedRow={this.props.focusedRow}
+        onCellClick={this.props.onCellClick}
       >
         {tableColumns}
       </TableComponent>

--- a/packages/veritone-react-common/src/components/SDOTable/index.js
+++ b/packages/veritone-react-common/src/components/SDOTable/index.js
@@ -44,6 +44,7 @@ export default class SDOTable extends React.Component {
         break;
       case 'number':
         formattedData = !Number.isNaN(data) ? NumberFormatter.format(data) : data;
+        break;
       default:
         formattedData = data;
     }

--- a/packages/veritone-react-common/src/components/SDOTable/index.js
+++ b/packages/veritone-react-common/src/components/SDOTable/index.js
@@ -5,6 +5,12 @@ import { map, startCase, partial, omit } from 'lodash';
 import DotDotDot from 'react-dotdotdot';
 import { format } from 'date-fns';
 
+const IntegerFormatter = new Intl.NumberFormat('en-US', {
+  maximumFractionDigits: 0
+});
+
+const NumberFormatter = new Intl.NumberFormat('en-US', {});
+
 export default class SDOTable extends React.Component {
   static propTypes = {
     data: arrayOf(object).isRequired,
@@ -33,6 +39,11 @@ export default class SDOTable extends React.Component {
       case 'geoPoint':
         formattedData = `[${data}]`;
         break;
+      case 'integer':
+        formattedData = Number.isInteger(data) ? IntegerFormatter.format(data) : data;
+        break;
+      case 'number':
+        formattedData = !Number.isNaN(data) ? NumberFormatter.format(data) : data;
       default:
         formattedData = data;
     }

--- a/packages/veritone-react-common/src/components/SDOTable/story.js
+++ b/packages/veritone-react-common/src/components/SDOTable/story.js
@@ -86,6 +86,175 @@ const schemaData = {
   }
 };
 
+const nestedSdoData = [
+  {
+    demographics: {
+      male: {
+        age65: 189290,
+        total: 367646,
+        age18_24: 0,
+        age25_34: 15464,
+        age35_49: 32655,
+        age50_54: 46684,
+        age55_64: 83553
+      },
+      total: 767342,
+      female: {
+        age65: 196927,
+        total: 399696,
+        age18_24: 13434,
+        age25_34: 19284,
+        age35_49: 42347,
+        age50_54: 50906,
+        age55_64: 76798
+      }
+    },
+    isAverage: true,
+    fileName: 'AVG Calculation',
+    networkCode: 'CNN',
+    programName: 'UNKNOWN',
+    datetimeStart: '2018-02-01T22:00:26.000Z',
+    datetimeEnd: '2018-02-01T22:02:28.000Z',
+    viewershipType: 'LV7',
+    uniqueCode: 'SDO 1'
+  },
+  {
+    demographics: {
+      male: {
+        age65: 1,
+        total: 2,
+        age18_24: 3,
+        age25_34: 4,
+        age35_49: 5,
+        age50_54: 6,
+        age55_64: 7
+      },
+      total: 200,
+      female: {
+        age65: 9,
+        total: 10,
+        age18_24: 11,
+        age25_34: 12,
+        age35_49: 13,
+        age50_54: 14,
+        age55_64: 15
+      }
+    },
+    isAverage: true,
+    fileName: 'AVG Calculation',
+    networkCode: 'CNN',
+    programName: 'UNKNOWN',
+    datetimeStart: '2018-02-01T22:00:26.000Z',
+    datetimeEnd: '2018-02-01T22:02:28.000Z',
+    viewershipType: 'LV7',
+    uniqueCode: 'SDO 2'
+  }
+];
+
+const twoLevelDeepSchemaData = {
+  id: { $id: '/properties/id', type: 'string' },
+  line: { $id: '/properties/line', type: 'string' },
+  dataId: { $id: '/properties/dataId', type: 'string' },
+  fileName: { $id: '/properties/fileName', type: 'string' },
+  uniqueCode: { $id: '/properties/uniqueCode', type: 'string' },
+  datetimeEnd: { $id: '/properties/datetimeEnd', type: 'string' },
+  networkCode: {
+    $id: '/properties/decorators/properties/networkCode',
+    type: 'string'
+  },
+  programName: { $id: '/properties/programName', type: 'string' },
+  demographics: {
+    $id: '/properties/demographics',
+    type: 'object',
+    properties: {
+      male: {
+        $id: '/properties/demographics/properties/male',
+        type: 'object',
+        properties: {
+          age65: {
+            $id: '/properties/demographics/properties/male/properties/age65',
+            type: 'integer'
+          },
+          total: {
+            $id: '/properties/demographics/properties/male/properties/total',
+            type: 'integer'
+          },
+          age18_24: {
+            $id: '/properties/demographics/properties/male/properties/age18_24',
+            type: 'integer'
+          },
+          age25_34: {
+            $id: '/properties/demographics/properties/male/properties/age25_34',
+            type: 'integer'
+          },
+          age35_49: {
+            $id: '/properties/demographics/properties/male/properties/age35_44',
+            type: 'integer'
+          },
+          age50_54: {
+            $id: '/properties/demographics/properties/male/properties/age50_54',
+            type: 'integer'
+          },
+          age55_64: {
+            $id: '/properties/demographics/properties/male/properties/age55_64',
+            type: 'integer'
+          }
+        }
+      },
+      total: {
+        $id: '/properties/demographics/properties/total',
+        type: 'integer'
+      },
+      female: {
+        $id: '/properties/demographics/properties/female',
+        type: 'object',
+        properties: {
+          age65: {
+            $id: '/properties/demographics/properties/female/properties/age65',
+            type: 'integer'
+          },
+          total: {
+            $id: '/properties/demographics/properties/female/properties/total',
+            type: 'integer'
+          },
+          age18_24: {
+            $id:
+              '/properties/demographics/properties/female/properties/age18_24',
+            type: 'integer'
+          },
+          age25_34: {
+            $id:
+              '/properties/demographics/properties/female/properties/age25_34',
+            type: 'integer'
+          },
+          age35_49: {
+            $id:
+              '/properties/demographics/properties/female/properties/age35_49',
+            type: 'integer'
+          },
+          age50_54: {
+            $id:
+              '/properties/demographics/properties/female/properties/age50_54',
+            type: 'integer'
+          },
+          age55_64: {
+            $id:
+              '/properties/demographics/properties/female/properties/age55_64',
+            type: 'integer'
+          }
+        }
+      }
+    }
+  },
+  datetimeStart: { $id: '/properties/datetimeStart', type: 'string' },
+  dataRegistryId: { $id: '/properties/dataRegistryId', type: 'string' },
+  viewershipType: { $id: '/properties/viewershipType', type: 'string' }
+};
+
 storiesOf('SDO', module).add('SDO Table', () => (
   <SDOTable data={sdoData} schema={schemaData} />
+));
+
+storiesOf('SDO', module).add('SDO Table multilevel schema', () => (
+  <SDOTable data={nestedSdoData} schema={twoLevelDeepSchemaData} />
 ));


### PR DESCRIPTION
https://steel-ventures.atlassian.net/browse/VTN-9936 (USOT: show Structured Data in SDO Engine output in CMS)

This PR is to merge https://github.com/veritone/veritone-sdk/pull/229 to master.
This has been tested on dev and stage: CMS MDP only.

1. DataTable: if no focused renderer provided - do not crash but render simple table with focused row as selected.
2. SdoTable: surface control to pass down focused row, and react on row/cell click.
3. Structured engine output should: a) highlight sdo table row for data for current media player time and b) should reposition media player time when user clicks on table row. For now highlighting only one row is supported.