### PR TITLE
VTN-9915 incorrect outputConfiguration for single tdo export

### DIFF
--- a/packages/veritone-widgets/README.md
+++ b/packages/veritone-widgets/README.md
@@ -325,6 +325,7 @@ The Veritone export engine outputs full screen dialog. This will fetch the engin
 * tdos: arrayOf(shape), array of tdo data objects that engine outputs will be exported for
   * shape: object with the following keys:
     * tdoId: string (required), the unique id of a tdo you want to export engine outputs for
+    * mentionId: string, the unique id of a mention you want to export engine outputs for. If a mentionId is provided the engine results of the mention will be returned rather than those of the tdo
     * startOffsetMs: number, an integer representing the number of milliseconds from the start of the tdo where the exported engine outputs will begin
     * stopOffsetMs: number, an integer representing the number of milliseconds from the start of the tdo where the exported engine outputs will end
 * onExport: func, specifies action to take when export button is clicked

--- a/packages/veritone-widgets/src/redux/modules/engineOutputExport/index.js
+++ b/packages/veritone-widgets/src/redux/modules/engineOutputExport/index.js
@@ -279,9 +279,12 @@ export const outputConfigsByCategoryId = state => {
         outputConfigsByCategoryId[config.categoryId] = [];
       }
       outputConfigsByCategoryId[config.categoryId].push(config);
-    } else if(config.engineId) {
+    } else if (config.engineId) {
       // Look up engine category id using engineId
-      const categoryId = get(getEngineById(state, config.engineId), 'category.id');
+      const categoryId = get(
+        getEngineById(state, config.engineId),
+        'category.id'
+      );
       if (!outputConfigsByCategoryId[categoryId]) {
         outputConfigsByCategoryId[categoryId] = [];
       }
@@ -308,7 +311,7 @@ export const fetchEngineRunsFailed = state =>
   get(local(state), 'fetchEngineRunsFailed');
 export const getSubtitleConfig = (state, categoryId) =>
   get(local(state), ['subtitleConfigCache', categoryId]);
-export const isBulkExport = (state) => get(local(state), 'isBulkExport');
+export const isBulkExport = state => get(local(state), 'isBulkExport');
 
 export const fetchEngineRuns = tdos => async (dispatch, getState) => {
   // TODO: Update the temporalDataObjects query to accept multiple ids.
@@ -418,11 +421,7 @@ export const toggleConfigExpand = categoryId => {
   };
 };
 
-export const selectFileType = (
-  selectedFileTypes,
-  categoryId,
-  engineId
-) => {
+export const selectFileType = (selectedFileTypes, categoryId, engineId) => {
   return {
     type: UPDATE_SELECTED_FILE_TYPES,
     payload: {

--- a/packages/veritone-widgets/src/redux/modules/engineOutputExport/index.js
+++ b/packages/veritone-widgets/src/redux/modules/engineOutputExport/index.js
@@ -321,7 +321,7 @@ export const fetchEngineRuns = tdos => async (dispatch, getState) => {
             engine {
               id
               name
-              signedLogoPath
+              signedIconPath
               iconPath
               category {
                 id

--- a/packages/veritone-widgets/src/redux/modules/engineOutputExport/index.js
+++ b/packages/veritone-widgets/src/redux/modules/engineOutputExport/index.js
@@ -191,7 +191,19 @@ export default createReducer(defaultState, {
     return {
       ...state,
       outputConfigurations: state.outputConfigurations.map(config => {
-        if (config.categoryId === categoryId) {
+        let engineCategoryId;
+        if (!config.categoryId && config.engineId) {
+          engineCategoryId = get(state, [
+            'enginesRan',
+            config.engineId,
+            'category',
+            'id'
+          ]);
+        }
+        if (
+          config.categoryId === categoryId ||
+          engineCategoryId === categoryId
+        ) {
           return {
             ...config,
             formats: config.formats.map(format => {
@@ -312,9 +324,10 @@ export const fetchEngineRunsFailed = state =>
 export const getSubtitleConfig = (state, categoryId) =>
   get(local(state), ['subtitleConfigCache', categoryId]);
 export const isBulkExport = state => get(local(state), 'isBulkExport');
-export const selectedFormats = state => get(local(state), 'outputConfigurations').reduce((accumulator, configObj) => {
-  return [...accumulator, ...configObj.formats];
-}, []);
+export const selectedFormats = state =>
+  get(local(state), 'outputConfigurations').reduce((accumulator, configObj) => {
+    return [...accumulator, ...configObj.formats];
+  }, []);
 
 export const fetchEngineRuns = tdos => async (dispatch, getState) => {
   // TODO: Update the temporalDataObjects query to accept multiple ids.
@@ -395,7 +408,6 @@ export const exportAndDownload = tdoData => async (dispatch, getState) => {
       message: 'Please select from at least one option'
     };
 
-    console.log(e);
     dispatch({
       type: EXPORT_AND_DOWNLOAD_FAILURE,
       error: true,

--- a/packages/veritone-widgets/src/redux/modules/engineOutputExport/saga.js
+++ b/packages/veritone-widgets/src/redux/modules/engineOutputExport/saga.js
@@ -24,7 +24,11 @@ function* watchErrors() {
             }
             break;
           case EXPORT_AND_DOWNLOAD_FAILURE:
-            message = 'Failed to export.';
+            if (get(action, 'payload.name') === 'no_formats_selected') {
+              message = get(action, 'payload.message');
+            } else {
+              message = 'Failed to export.';
+            }
             break;
           default:
             message = action.payload.message;

--- a/packages/veritone-widgets/src/redux/modules/engineOutputExport/saga.js
+++ b/packages/veritone-widgets/src/redux/modules/engineOutputExport/saga.js
@@ -1,4 +1,5 @@
 import { all, fork, takeEvery, put } from 'redux-saga/effects';
+import { get } from 'lodash';
 import {
   FETCH_ENGINE_RUNS_FAILURE,
   EXPORT_AND_DOWNLOAD_FAILURE,
@@ -16,7 +17,11 @@ function* watchErrors() {
         let message;
         switch (action.type) {
           case FETCH_ENGINE_RUNS_FAILURE:
-            message = 'Failed to get engine runs for one or more recordings.';
+            if (get(action, 'payload[0].name') === 'not_found') {
+              message = 'Unable to export due to restricted file access';
+            } else {
+              message = 'Failed to get engine runs for one or more recordings.';
+            }
             break;
           case EXPORT_AND_DOWNLOAD_FAILURE:
             message = 'Failed to export.';

--- a/packages/veritone-widgets/src/widgets/EngineOutputExport/EngineCategoryConfig.js
+++ b/packages/veritone-widgets/src/widgets/EngineOutputExport/EngineCategoryConfig.js
@@ -113,7 +113,7 @@ export default class EngineCategoryConfig extends Component {
 
     const defaultSubtitleConfig = {
       linesPerScreen: 2,
-      maxLinesPerCaptionLine: 32,
+      maxCharacterPerLine: 32,
       newLineOnPunctuation: false
     };
 

--- a/packages/veritone-widgets/src/widgets/EngineOutputExport/EngineCategoryConfig.js
+++ b/packages/veritone-widgets/src/widgets/EngineOutputExport/EngineCategoryConfig.js
@@ -108,11 +108,13 @@ export default class EngineCategoryConfig extends Component {
     forEach(engineCategoryConfigs, config => {
       if (get(config, 'formats.length')) {
         forEach(config.formats, format => {
-          const exportFormat = find(category.exportFormats, {format: format.extension});
+          const exportFormat = find(category.exportFormats, {
+            format: format.extension
+          });
           if (exportFormat && includes(exportFormat.types, 'subtitle')) {
             hasSubtitleFormatsSelected = true;
           }
-        })
+        });
       }
     });
 
@@ -147,7 +149,8 @@ export default class EngineCategoryConfig extends Component {
             {engineCategoryConfigs.map(config => {
               return (
                 <EngineConfigItem
-                  key={`engine-config-item-${config.engineId || config.categoryId}`}
+                  key={`engine-config-item-${config.engineId ||
+                    config.categoryId}`}
                   engineId={config.engineId}
                   categoryId={category.id}
                   formats={config.formats}

--- a/packages/veritone-widgets/src/widgets/EngineOutputExport/EngineCategoryConfig.js
+++ b/packages/veritone-widgets/src/widgets/EngineOutputExport/EngineCategoryConfig.js
@@ -48,7 +48,7 @@ export default class EngineCategoryConfig extends Component {
     }).isRequired,
     engineCategoryConfigs: arrayOf(
       shape({
-        engineId: string.isRequired,
+        engineId: string,
         categoryId: string,
         formats: arrayOf(
           shape({

--- a/packages/veritone-widgets/src/widgets/EngineOutputExport/EngineCategoryConfig.js
+++ b/packages/veritone-widgets/src/widgets/EngineOutputExport/EngineCategoryConfig.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { forEach, get } from 'lodash';
 import { string, bool, shape, func, arrayOf, number } from 'prop-types';
 import { connect } from 'react-redux';
@@ -49,7 +49,7 @@ export default class EngineCategoryConfig extends Component {
     engineCategoryConfigs: arrayOf(
       shape({
         engineId: string.isRequired,
-        categoryId: string.isRequired,
+        categoryId: string,
         formats: arrayOf(
           shape({
             extension: string.isRequired,
@@ -65,7 +65,6 @@ export default class EngineCategoryConfig extends Component {
     applySubtitleConfigs: func,
     expanded: bool,
     onExpandConfigs: func,
-    bulkExportEnabled: bool,
     initialSubtitleConfig: shape({
       maxCharacterPerLine: number,
       newLineOnPunctuation: bool,
@@ -102,7 +101,6 @@ export default class EngineCategoryConfig extends Component {
       engineCategoryConfigs,
       onExpandConfigs,
       expanded,
-      bulkExportEnabled,
       initialSubtitleConfig
     } = this.props;
 
@@ -141,26 +139,16 @@ export default class EngineCategoryConfig extends Component {
         </ListItem>
         <Collapse in={expanded} timeout="auto" unmountOnExit>
           <List disablePadding>
-            {bulkExportEnabled ? (
-              <EngineConfigItem
-                categoryId={category.id}
-                formats={engineCategoryConfigs[0].formats}
-              />
-            ) : (
-              <Fragment>
-                {engineCategoryConfigs.map(config => {
-                  return (
-                    <EngineConfigItem
-                      key={`engine-config-item-${config.engineId}`}
-                      engineId={config.engineId}
-                      categoryId={config.categoryId}
-                      formats={config.formats}
-                    />
-                  );
-                })}
-              </Fragment>
-            )}
-
+            {engineCategoryConfigs.map(config => {
+              return (
+                <EngineConfigItem
+                  key={`engine-config-item-${config.engineId || config.categoryId}`}
+                  engineId={config.engineId}
+                  categoryId={category.id}
+                  formats={config.formats}
+                />
+              );
+            })}
             {hasFormatsSelected && (
               <ListItem className={styles.engineListItem}>
                 <div className={styles.customizeOutputBox}>

--- a/packages/veritone-widgets/src/widgets/EngineOutputExport/EngineCategoryConfig.js
+++ b/packages/veritone-widgets/src/widgets/EngineOutputExport/EngineCategoryConfig.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { forEach, get } from 'lodash';
+import { forEach, get, includes, find } from 'lodash';
 import { string, bool, shape, func, arrayOf, number } from 'prop-types';
 import { connect } from 'react-redux';
 
@@ -104,10 +104,15 @@ export default class EngineCategoryConfig extends Component {
       initialSubtitleConfig
     } = this.props;
 
-    let hasFormatsSelected = false;
+    let hasSubtitleFormatsSelected = false;
     forEach(engineCategoryConfigs, config => {
       if (get(config, 'formats.length')) {
-        hasFormatsSelected = true;
+        forEach(config.formats, format => {
+          const exportFormat = find(category.exportFormats, {format: format.extension});
+          if (exportFormat && includes(exportFormat.types, 'subtitle')) {
+            hasSubtitleFormatsSelected = true;
+          }
+        })
       }
     });
 
@@ -149,7 +154,7 @@ export default class EngineCategoryConfig extends Component {
                 />
               );
             })}
-            {hasFormatsSelected && (
+            {hasSubtitleFormatsSelected && (
               <ListItem className={styles.engineListItem}>
                 <div className={styles.customizeOutputBox}>
                   <ClosedCaptionIcon className={styles.closedCaptionIcon} />

--- a/packages/veritone-widgets/src/widgets/EngineOutputExport/EngineCategoryConfigList.js
+++ b/packages/veritone-widgets/src/widgets/EngineOutputExport/EngineCategoryConfigList.js
@@ -67,7 +67,7 @@ export default class EngineCategoryConfigList extends Component {
       fetchingEngineRuns,
       outputConfigsByCategoryId,
       expandedCategories,
-      toggleConfigExpand,
+      toggleConfigExpand
     } = this.props;
 
     return (

--- a/packages/veritone-widgets/src/widgets/EngineOutputExport/EngineCategoryConfigList.js
+++ b/packages/veritone-widgets/src/widgets/EngineOutputExport/EngineCategoryConfigList.js
@@ -38,7 +38,7 @@ export default class EngineCategoryConfigList extends Component {
   static propTypes = {
     tdos: arrayOf(
       shape({
-        tdoId: string,
+        tdoId: string.isRequired,
         mentionId: string,
         startOffsetMs: number,
         stopOffsetMs: number

--- a/packages/veritone-widgets/src/widgets/EngineOutputExport/EngineCategoryConfigList.js
+++ b/packages/veritone-widgets/src/widgets/EngineOutputExport/EngineCategoryConfigList.js
@@ -38,7 +38,8 @@ export default class EngineCategoryConfigList extends Component {
   static propTypes = {
     tdos: arrayOf(
       shape({
-        tdoId: string.isRequired,
+        tdoId: string,
+        mentionId: string,
         startOffsetMs: number,
         stopOffsetMs: number
       })
@@ -63,11 +64,10 @@ export default class EngineCategoryConfigList extends Component {
 
   render() {
     const {
-      tdos,
       fetchingEngineRuns,
       outputConfigsByCategoryId,
       expandedCategories,
-      toggleConfigExpand
+      toggleConfigExpand,
     } = this.props;
 
     return (
@@ -80,7 +80,6 @@ export default class EngineCategoryConfigList extends Component {
                   categoryId={key}
                   engineCategoryConfigs={outputConfigsByCategoryId[key]}
                   expanded={expandedCategories[key]}
-                  bulkExportEnabled={tdos.length > 1}
                   onExpandConfigs={toggleConfigExpand}
                 />
                 {index !==

--- a/packages/veritone-widgets/src/widgets/EngineOutputExport/EngineConfigItem.js
+++ b/packages/veritone-widgets/src/widgets/EngineOutputExport/EngineConfigItem.js
@@ -11,6 +11,7 @@ import Select from '@material-ui/core/Select';
 import Input from '@material-ui/core/Input';
 import MenuItem from '@material-ui/core/MenuItem';
 import Checkbox from '@material-ui/core/Checkbox';
+import Icon from '@material-ui/core/Icon';
 import InfoIcon from '@material-ui/icons/Info';
 import Tooltip from '@material-ui/core/Tooltip';
 
@@ -39,7 +40,7 @@ export default class EngineConfigItem extends Component {
     engine: shape({
       id: string,
       name: string.isRequired,
-      signedLogoPath: string
+      signedIconPath: string
     }),
     category: shape({
       exportFormats: arrayOf(
@@ -79,9 +80,9 @@ export default class EngineConfigItem extends Component {
 
     return (
       <ListItem className={styles.engineListItem}>
-        {engine && (
-          <img className={styles.engineLogo} src={engine.signedLogoPath} />
-        )}
+        {engine && engine.signedIconPath ? (
+            <img className={styles.engineLogo} src={engine.signedIconPath} />
+          ) : <Icon className={'icon-engines'}/>}
         <ListItemText
           classes={{ primary: styles.engineNameText }}
           primary={

--- a/packages/veritone-widgets/src/widgets/EngineOutputExport/EngineConfigItem.js
+++ b/packages/veritone-widgets/src/widgets/EngineOutputExport/EngineConfigItem.js
@@ -82,8 +82,10 @@ export default class EngineConfigItem extends Component {
     return (
       <ListItem className={styles.engineListItem}>
         {engine && engine.signedIconPath ? (
-            <img className={styles.engineLogo} src={engine.signedIconPath} />
-          ) : <Icon className={cx(styles['default-engine-icon'], 'icon-engines')}/>}
+          <img className={styles.engineLogo} src={engine.signedIconPath} />
+        ) : (
+          <Icon className={cx(styles['default-engine-icon'], 'icon-engines')} />
+        )}
         <ListItemText
           classes={{ primary: styles.engineNameText }}
           primary={
@@ -108,7 +110,11 @@ export default class EngineConfigItem extends Component {
           value={selectedFileExtensions}
           // eslint-disable-next-line
           onChange={evt =>
-            selectFileType(evt.target.value, categoryId || get(engine, 'category.id'), engineId)
+            selectFileType(
+              evt.target.value,
+              categoryId || get(engine, 'category.id'),
+              engineId
+            )
           }
           // eslint-disable-next-line
           renderValue={value => `.${value.join(', .')}`}

--- a/packages/veritone-widgets/src/widgets/EngineOutputExport/EngineConfigItem.js
+++ b/packages/veritone-widgets/src/widgets/EngineOutputExport/EngineConfigItem.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { arrayOf, bool, number, shape, string, func } from 'prop-types';
 import { includes, get } from 'lodash';
+import cx from 'classnames';
 import { modules } from 'veritone-redux-common';
 const { user: userModule } = modules;
 
@@ -82,7 +83,7 @@ export default class EngineConfigItem extends Component {
       <ListItem className={styles.engineListItem}>
         {engine && engine.signedIconPath ? (
             <img className={styles.engineLogo} src={engine.signedIconPath} />
-          ) : <Icon className={'icon-engines'}/>}
+          ) : <Icon className={cx(styles['default-engine-icon'], 'icon-engines')}/>}
         <ListItemText
           classes={{ primary: styles.engineNameText }}
           primary={

--- a/packages/veritone-widgets/src/widgets/EngineOutputExport/EngineConfigItem.js
+++ b/packages/veritone-widgets/src/widgets/EngineOutputExport/EngineConfigItem.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { arrayOf, bool, number, shape, string, func } from 'prop-types';
-import { includes } from 'lodash';
+import { includes, get } from 'lodash';
 import { modules } from 'veritone-redux-common';
 const { user: userModule } = modules;
 
@@ -106,7 +106,7 @@ export default class EngineConfigItem extends Component {
           value={selectedFileExtensions}
           // eslint-disable-next-line
           onChange={evt =>
-            selectFileType(evt.target.value, categoryId, engineId, !engine)
+            selectFileType(evt.target.value, categoryId || get(engine, 'category.id'), engineId)
           }
           // eslint-disable-next-line
           renderValue={value => `.${value.join(', .')}`}

--- a/packages/veritone-widgets/src/widgets/EngineOutputExport/SubtitleConfigForm.js
+++ b/packages/veritone-widgets/src/widgets/EngineOutputExport/SubtitleConfigForm.js
@@ -25,7 +25,7 @@ const SubtitleConfigForm = reduxForm({
           <Grid item>
             <Field
               type="number"
-              name="maxLinesPerCaptionLine"
+              name="maxCharacterPerLine"
               style={{ width: 50 }}
               component={formComponents.TextField}
               // eslint-disable-next-line

--- a/packages/veritone-widgets/src/widgets/EngineOutputExport/index.js
+++ b/packages/veritone-widgets/src/widgets/EngineOutputExport/index.js
@@ -114,9 +114,7 @@ class EngineOutputExport extends Component {
               }Export and Download`}</div>
               <div className={styles.subtitle}>
                 Select the category, engine, and format type you would like to
-                export below based on your selection. Please note that larger
-                exports will be available through a download link sent to your
-                account email.
+                export below based on your selection.
               </div>
             </Grid>
             <Grid item xs={1}>

--- a/packages/veritone-widgets/src/widgets/EngineOutputExport/index.js
+++ b/packages/veritone-widgets/src/widgets/EngineOutputExport/index.js
@@ -140,7 +140,7 @@ class EngineOutputExport extends Component {
               <Card className={styles.formatSelection}>
                 <CardHeader
                   title="Export Format Selection"
-                  subheader="Select from available engine categories and engines that have run on these file(s). Then select your formats you would like to include in your download."
+                  subheader="Select the preferred engine categories and engines that have processed the file(s). Then choose the applicable format(s) to include in your export."
                   classes={{
                     title: styles.exportFormatTitle,
                     subheader: styles.exportFormatSubHeader
@@ -158,7 +158,7 @@ class EngineOutputExport extends Component {
                       color="primary"
                     />
                   }
-                  subheader="Include the Audio and Video media from your selected file(s) in your export. (This will increase download time)"
+                  subheader="Include the media file with your format export. Downloading the file may increase the wait time."
                   classes={{
                     title: styles.exportFormatTitle,
                     subheader: styles.exportFormatSubHeader

--- a/packages/veritone-widgets/src/widgets/EngineOutputExport/index.js
+++ b/packages/veritone-widgets/src/widgets/EngineOutputExport/index.js
@@ -50,7 +50,8 @@ class EngineOutputExport extends Component {
   static propTypes = {
     tdos: arrayOf(
       shape({
-        tdoId: string.isRequired,
+        tdoId: string,
+        mentionId: string,
         startOffsetMs: number,
         stopOffsetMs: number
       })

--- a/packages/veritone-widgets/src/widgets/EngineOutputExport/index.js
+++ b/packages/veritone-widgets/src/widgets/EngineOutputExport/index.js
@@ -50,7 +50,7 @@ class EngineOutputExport extends Component {
   static propTypes = {
     tdos: arrayOf(
       shape({
-        tdoId: string,
+        tdoId: string.isRequired,
         mentionId: string,
         startOffsetMs: number,
         stopOffsetMs: number

--- a/packages/veritone-widgets/src/widgets/EngineOutputExport/index.js
+++ b/packages/veritone-widgets/src/widgets/EngineOutputExport/index.js
@@ -114,7 +114,7 @@ class EngineOutputExport extends Component {
               }Export and Download`}</div>
               <div className={styles.subtitle}>
                 Select the category, engine, and format type you would like to
-                export below based on your selection.
+                export with the option to download the corresponding file.
               </div>
             </Grid>
             <Grid item xs={1}>

--- a/packages/veritone-widgets/src/widgets/EngineOutputExport/index.test.js
+++ b/packages/veritone-widgets/src/widgets/EngineOutputExport/index.test.js
@@ -256,7 +256,6 @@ describe('EngineConfigItem', () => {
           payload: {
             selectedFileTypes: ['vlf'],
             categoryId: testEngine.category.id,
-            applyAll: false,
             engineId: testEngine.id
           }
         }
@@ -291,7 +290,7 @@ describe('EngineConfigItem', () => {
       expect(wrapper.find(ListItemText).html()).toMatch(/All Engines/);
     });
 
-    it('should call selectFileType with applyAll equal to true when file type is selected', () => {
+    it('should call selectFileType when file type is selected', () => {
       wrapper.find(Select).prop('onChange')({ target: { value: ['vlf'] } });
 
       const actions = store.getActions();
@@ -301,7 +300,7 @@ describe('EngineConfigItem', () => {
           payload: {
             selectedFileTypes: ['vlf'],
             categoryId: testEngine.category.id,
-            applyAll: true
+            engineId: undefined
           }
         }
       ];

--- a/packages/veritone-widgets/src/widgets/EngineOutputExport/index.test.js
+++ b/packages/veritone-widgets/src/widgets/EngineOutputExport/index.test.js
@@ -24,7 +24,7 @@ const mockStore = configureMockStore();
 const testEngine = {
   id: 'testEngineId',
   name: 'Test Engine',
-  signedLogoPath:
+  signedIconPath:
     'https://static.veritone.com/assets/favicon/favicon-32x32.png?v=lkgpRBRLYl',
   category: {
     id: 'testCategoryId',

--- a/packages/veritone-widgets/src/widgets/EngineOutputExport/styles.scss
+++ b/packages/veritone-widgets/src/widgets/EngineOutputExport/styles.scss
@@ -75,6 +75,10 @@
     background-color: $grey-3;
   }
 
+  .default-engine-icon {
+    margin-left: 30px;
+  }
+
   .engineNameText {
     @include mui-text('body1');
     align-items: center;


### PR DESCRIPTION
https://steel-ventures.atlassian.net/browse/VTN-9915

Changed how outputConfigurations are initialized. If there is more than one tdo object passed into the component then it is bulk export mode and we need to create only a single outputConfigurations object with an engine categoryId. This tells the API that the configuration can be applied to all engines ran on that tdo that fall under that engine category. If only a single tdo is passed in the tdo objects array then an outputConfigurations object needs to be created for each engine ran on that tdo and only include the engineId since the categoryId take precedence and the engineId will be ignored.

I also updated all the child components to reflect these changes.

This should not be a breaking change as it is all internal to the EngineOutputExport component and props passed into the widget/smart component remain the same except you can include mentionId in the tdo objects which I added to the readme and allows the user to export a mention.

https://steel-ventures.atlassian.net/browse/VTN-10086

Updated the text changes requested by Michael Kennedy

https://steel-ventures.atlassian.net/browse/VTN-10092

Hide the box and button to configure subtitle settings unless the user has selected a subtitle format in EngineCategoryConfig component.

