### PR TITLE
Remove the engineOutput export functionality from behind the beta flag.

### DIFF
--- a/packages/veritone-widgets/src/widgets/MediaDetails/index.js
+++ b/packages/veritone-widgets/src/widgets/MediaDetails/index.js
@@ -118,7 +118,6 @@ const programLiveImageNullState =
       id
     ),
     categoryExportFormats: mediaDetailsModule.categoryExportFormats(state, id),
-    betaFlagEnabled: userModule.hasFeature(state, 'beta'),
     exportClosedCaptionsEnabled: userModule.hasFeature(
       state,
       'exportClosedCaptions'
@@ -359,7 +358,6 @@ class MediaDetailsWidget extends React.Component {
       })
     ),
     createQuickExport: func.isRequired,
-    betaFlagEnabled: bool.isRequired,
     onExport: func,
     exportClosedCaptionsEnabled: bool,
     bulkEditEnabled: bool,
@@ -865,7 +863,6 @@ class MediaDetailsWidget extends React.Component {
       isSavingEngineResults,
       alertDialogConfig,
       categoryExportFormats,
-      betaFlagEnabled,
       onExport,
       exportClosedCaptionsEnabled,
       bulkEditEnabled
@@ -893,7 +890,7 @@ class MediaDetailsWidget extends React.Component {
         </MenuItem>
       );
     }
-    if (onExport && categoryExportFormats.length && betaFlagEnabled) {
+    if (onExport && categoryExportFormats.length) {
       moreMenuItems.push(
         <ExportMenuItem
           key="quick-export"


### PR DESCRIPTION
I removed the engineOutput export from behind the beta feature flag. The "Quick Export" menu item should now appear for all users in the more dropdown whether or not the bet flag is turned on.

@jordanheadley 