### PR TITLE
ignore stylelint rule that conflicts with prettier

### DIFF
--- a/packages/veritone-dev-env/.stylelintrc.js
+++ b/packages/veritone-dev-env/.stylelintrc.js
@@ -9,9 +9,13 @@ module.exports = {
     ],
     'no-eol-whitespace': null,
     'declaration-empty-line-before': null,
-    'at-rule-no-unknown': [true, {
-      ignoreAtRules: ["import", "include", "mixin", "if"]
-    }],
-    'declaration-colon-newline-after': null // prettier conflict
+    'at-rule-no-unknown': [
+      true,
+      {
+        ignoreAtRules: ['import', 'include', 'mixin', 'if']
+      }
+    ],
+    'declaration-colon-newline-after': null, // prettier conflict
+    'value-list-comma-newline-after': null
   }
 };


### PR DESCRIPTION
disables `value-list-comma-newline-after` because it conflicts with prettier