### PR TITLE
Feature/vtn 10905 hide oauth adapters from dropdown

### DIFF
--- a/packages/veritone-react-common/src/components/SourceConfiguration/SchemaDrivenSelectForm/index.js
+++ b/packages/veritone-react-common/src/components/SourceConfiguration/SchemaDrivenSelectForm/index.js
@@ -114,6 +114,13 @@ export default class DynamicSelect extends React.Component {
   render() {
     const { sourceTypes, currentSourceType } = this.props;
     const sourceTypesMenu = sourceTypes.map((type, index) => {
+      // TODO: Remove this and add a more data driven approach. The API doesn't
+      // indicate whether or not it is a oauth required source type so we are
+      // using hard coded ids for now. (dropbox === '12' and google drive === '14')
+      const oauthRequiredSourceTypeIds = ['12','14'];
+      if (includes(oauthRequiredSourceTypeIds, type.id)) {
+        return null;
+      }
       return (
         <MenuItem value={index} id={type.id} key={type.id}>
           {type.name}

--- a/packages/veritone-react-common/src/components/SourceTypeField/index.js
+++ b/packages/veritone-react-common/src/components/SourceTypeField/index.js
@@ -130,11 +130,11 @@ export default class SourceTypeField extends React.Component {
 
     return (
       <FieldTypeComponent
+        {...rest}
         id={id}
         onChange={this.handleChange}
         options={filteredOptions || []}
         multiple={isMultiple}
-        {...rest}
       />
     );
   }


### PR DESCRIPTION
https://steel-ventures.atlassian.net/browse/VTN-10905

Filter out the google drive and dropbox source types from the source type select dropdown for creating a source. A source is created for these source types on the fly when creating an ingestion job so these sources can't be selected anyway.

https://steel-ventures.atlassian.net/browse/VTN-10902

Fixed a bug where the options prop was being overwritten for the dropdown fields in source creation dialog so the dropdowns were not working.