### PR TITLE
VTN-11574 dynamically run widget sagas (again)

### DIFF
--- a/packages/veritone-widgets/src/redux/modules/veritoneApp/index.js
+++ b/packages/veritone-widgets/src/redux/modules/veritoneApp/index.js
@@ -4,22 +4,32 @@ const { createReducer } = helpers;
 
 export const namespace = 'veritoneApp';
 
-const WIDGET_ADDED = 'vtn/veritoneApp/WIDGET_ADDED';
-const WIDGET_REMOVED = 'vtn/veritoneApp/WIDGET_REMOVED';
+export const WIDGET_ADDED = 'vtn/veritoneApp/WIDGET_ADDED';
+export const WIDGET_REMOVED = 'vtn/veritoneApp/WIDGET_REMOVED';
 
 const defaultState = {
   widgets: []
 };
 
 const reducer = createReducer(defaultState, {
-  [WIDGET_ADDED](state, { payload: widget }) {
+  [WIDGET_ADDED](
+    state,
+    {
+      payload: { widget }
+    }
+  ) {
     return {
       ...state,
       widgets: [...state.widgets, widget]
     };
   },
 
-  [WIDGET_REMOVED](state, { payload: widget }) {
+  [WIDGET_REMOVED](
+    state,
+    {
+      payload: { widget }
+    }
+  ) {
     return {
       ...state,
       widgets: without(state.widgets, widget)
@@ -33,17 +43,17 @@ function local(state) {
   return state[namespace];
 }
 
-export function widgetAdded(widget) {
+export function widgetAdded(widget, saga) {
   return {
     type: WIDGET_ADDED,
-    payload: widget
+    payload: { widget, saga }
   };
 }
 
-export function widgetRemoved(widget) {
+export function widgetRemoved(widget, saga) {
   return {
     type: WIDGET_REMOVED,
-    payload: widget
+    payload: { widget, saga }
   };
 }
 

--- a/packages/veritone-widgets/src/redux/modules/veritoneApp/saga.js
+++ b/packages/veritone-widgets/src/redux/modules/veritoneApp/saga.js
@@ -1,5 +1,14 @@
 import { isFunction, get } from 'lodash';
-import { fork, call, takeLatest, put, select } from 'redux-saga/effects';
+import {
+  all,
+  fork,
+  call,
+  takeLatest,
+  takeEvery,
+  put,
+  select,
+  cancel
+} from 'redux-saga/effects';
 import { modules } from 'veritone-redux-common';
 const { user: userModule, auth: authModule } = modules;
 
@@ -40,6 +49,49 @@ export function* watchAppAuth() {
   );
 }
 
+const widgetSagaRegistry = new Map();
+function* handleWidgetRegistration({ payload: { saga } }) {
+  if (saga) {
+    const runningSagasEntry = widgetSagaRegistry.get(saga) || {};
+    const alreadyRunningCount = runningSagasEntry.count || 0;
+    let task = runningSagasEntry.task;
+
+    if (!task) {
+      task = yield fork(saga);
+    }
+
+    widgetSagaRegistry.set(saga, {
+      task,
+      count: alreadyRunningCount + 1
+    });
+  }
+}
+
+function* handleWidgetUnregistration({ payload: { saga } }) {
+  if (saga) {
+    const runningSagasEntry = widgetSagaRegistry.get(saga);
+    const alreadyRunningCount = runningSagasEntry.count;
+    const task = runningSagasEntry.task;
+    const isUnregisteringLastInstanceOfWidget = alreadyRunningCount === 1;
+
+    if (isUnregisteringLastInstanceOfWidget) {
+      yield cancel(task);
+    }
+
+    widgetSagaRegistry.set(saga, {
+      task: isUnregisteringLastInstanceOfWidget ? null : task,
+      count: alreadyRunningCount - 1
+    });
+  }
+}
+
+function* watchWidgetRegistration() {
+  yield all([
+    takeEvery(appModule.WIDGET_ADDED, handleWidgetRegistration),
+    takeEvery(appModule.WIDGET_REMOVED, handleWidgetUnregistration)
+  ]);
+}
+
 export default function* root() {
-  yield fork(watchAppAuth);
+  yield all([fork(watchAppAuth), fork(watchWidgetRegistration)]);
 }

--- a/packages/veritone-widgets/src/redux/rootSaga.js
+++ b/packages/veritone-widgets/src/redux/rootSaga.js
@@ -5,16 +5,7 @@ const {
 } = modules;
 
 import appRootSaga from './modules/veritoneApp/saga';
-import filePickerRootSaga from './modules/filePicker/filePickerSaga';
-import engineSelectionRootSaga from './modules/engineSelection/saga';
-import engineOutputExportSaga from './modules/engineOutputExport/saga';
 
 export default function* root() {
-  yield all([
-    fork(authRootSaga),
-    fork(filePickerRootSaga),
-    fork(appRootSaga),
-    fork(engineSelectionRootSaga),
-    fork(engineOutputExportSaga)
-  ]);
+  yield all([fork(authRootSaga), fork(appRootSaga)]);
 }

--- a/packages/veritone-widgets/src/shared/VeritoneApp.js
+++ b/packages/veritone-widgets/src/shared/VeritoneApp.js
@@ -25,13 +25,13 @@ class _VeritoneApp {
     this._theme = config && config.theme;
   }
 
-  _register(widget) {
-    this._store.dispatch(appModule.widgetAdded(widget));
+  _register(widget, saga) {
+    this._store.dispatch(appModule.widgetAdded(widget, saga));
     this._renderReactApp();
   }
 
-  _unregister(widget) {
-    this._store.dispatch(appModule.widgetRemoved(widget));
+  _unregister(widget, saga) {
+    this._store.dispatch(appModule.widgetRemoved(widget, saga));
     this._renderReactApp();
   }
 

--- a/packages/veritone-widgets/src/shared/widget.js
+++ b/packages/veritone-widgets/src/shared/widget.js
@@ -2,7 +2,7 @@ import { forOwn } from 'lodash';
 import { guid } from './util';
 import VeritoneApp from './VeritoneApp';
 
-export default function widget(Component) {
+export default function widget(Component, saga) {
   return class Widget {
     constructor({ elId, widgetId, ...props }) {
       this._elId = elId;
@@ -11,12 +11,12 @@ export default function widget(Component) {
       this._id = guid();
 
       if (this._app) {
-        this._app._register(this);
+        this._app._register(this, saga);
       }
     }
 
     destroy() {
-      this._app._unregister(this);
+      this._app._unregister(this, saga);
     }
 
     setRefProperties(ref) {

--- a/packages/veritone-widgets/src/widgets/EngineOutputExport/index.js
+++ b/packages/veritone-widgets/src/widgets/EngineOutputExport/index.js
@@ -17,6 +17,7 @@ import CloseIcon from '@material-ui/icons/Close';
 import styles from './styles.scss';
 
 import * as engineOutputExportModule from '../../redux/modules/engineOutputExport';
+import engineOutputExportSaga from '../../redux/modules/engineOutputExport/saga';
 import widget from '../../shared/widget';
 import EngineCategoryConfigList from './EngineCategoryConfigList';
 
@@ -286,5 +287,8 @@ class EngineOutputExportWidgetComponent extends Component {
   }
 }
 
-const EngineOutputExportWidget = widget(EngineOutputExportWidgetComponent);
+const EngineOutputExportWidget = widget(
+  EngineOutputExportWidgetComponent,
+  engineOutputExportSaga
+);
 export { EngineOutputExport as default, EngineOutputExportWidget };

--- a/packages/veritone-widgets/src/widgets/EngineSelection/index.js
+++ b/packages/veritone-widgets/src/widgets/EngineSelection/index.js
@@ -17,6 +17,7 @@ import EngineListView from './EngineListView/';
 import EngineDetailView from './EngineDetailView/';
 
 import * as engineSelectionModule from '../../redux/modules/engineSelection';
+import engineSelectionRootSaga from '../../redux/modules/engineSelection/saga';
 
 import widget from '../../shared/widget';
 
@@ -166,5 +167,5 @@ class EngineSelection extends React.Component {
   }
 }
 
-const EngineSelectionWidget = widget(EngineSelection);
+const EngineSelectionWidget = widget(EngineSelection, engineSelectionRootSaga);
 export { EngineSelectionWidget };

--- a/packages/veritone-widgets/src/widgets/FilePicker/index.js
+++ b/packages/veritone-widgets/src/widgets/FilePicker/index.js
@@ -10,6 +10,7 @@ import {
 } from 'veritone-react-common';
 
 import * as filePickerModule from '../../redux/modules/filePicker';
+import filePickerRootSaga from '../../redux/modules/filePicker/filePickerSaga';
 import { guid } from '../../shared/util';
 import widget from '../../shared/widget';
 
@@ -173,5 +174,5 @@ class FilePickerWidgetComponent extends React.Component {
   }
 }
 
-const FilePickerWidget = widget(FilePickerWidgetComponent);
+const FilePickerWidget = widget(FilePickerWidgetComponent, filePickerRootSaga);
 export { FilePicker as default, FilePickerWidget };


### PR DESCRIPTION
this was previously merged but reverted https://github.com/veritone/veritone-sdk/pull/248

in this PR i forgot to account for storybook, and I didn't document the new requirement that smart component sagas be included in user-apps root sagas.

I also didn’t account for dependencies such as when a widget uses a smart component that has a saga.

More thought is needed.

Add a thing in BaseStory that starts/stops sagas, and add the requirement to README.md that if you use a smart component, you have to add its saga to your app's root saga.

also need to export the sagas if they aren't already.

it should probably be a major version because apps need to remove existing smart component sagas from their own root saga.