### PR TITLE
VTN-11610 emit event when face entity is updated.

### DIFF
--- a/packages/veritone-widgets/src/redux/modules/mediaDetails/index.js
+++ b/packages/veritone-widgets/src/redux/modules/mediaDetails/index.js
@@ -51,6 +51,8 @@ export const CREATE_QUICK_EXPORT = `${namespace}_CREATE_QUICK_EXPORT`;
 export const CREATE_QUICK_EXPORT_SUCCESS = `${namespace}_CREATE_QUICK_EXPORT_SUCCESS`;
 export const CREATE_QUICK_EXPORT_FAILURE = `${namespace}_CREATE_QUICK_EXPORT_FAILURE`;
 export const CANCEL_EDIT = `${namespace}_CANCEL_EDIT`;
+export const INSERT_INTO_INDEX_FAILURE = `${namespace}_INSERT_INTO_INDEX_FAILURE`;
+export const EMIT_ENTITY_UPDATED_EVENT_FAILURE = `${namespace}_EMIT_ENTITY_UPDATED_EVENT_FAILURE`;
 
 const defaultMDPState = {
   engineCategories: [],
@@ -710,7 +712,31 @@ export default createReducer(defaultState, {
     return {
       ...state
     };
-  }
+  },
+  [INSERT_INTO_INDEX_FAILURE](
+    state,
+    {
+      meta: { error }
+    }
+  ) {
+    const errorMessage = get(error, 'message', error);
+    return {
+      ...state,
+      error: errorMessage || 'unknown error'
+    };
+  },
+  [EMIT_ENTITY_UPDATED_EVENT_FAILURE](
+    state,
+    {
+      meta: { error }
+    }
+  ) {
+    const errorMessage = get(error, 'message', error);
+    return {
+      ...state,
+      error: errorMessage || 'unknown error'
+    };
+  },
 });
 
 const local = state => state[namespace];
@@ -953,6 +979,16 @@ export const restoreOriginalEngineResultsSuccess = widgetId => ({
 export const cancelEdit = (widgetId, selectedEngineId) => ({
   type: CANCEL_EDIT,
   meta: { widgetId, selectedEngineId }
+});
+
+export const insertIntoIndexFailure = error => ({
+  type: INSERT_INTO_INDEX_FAILURE,
+  meta: { error }
+});
+
+export const emitEntityUpdatedEventFailure = error => ({
+  type: EMIT_ENTITY_UPDATED_EVENT_FAILURE,
+  meta: { error }
 });
 
 export const createQuickExport = (

--- a/packages/veritone-widgets/src/redux/modules/mediaDetails/queries.js
+++ b/packages/veritone-widgets/src/redux/modules/mediaDetails/queries.js
@@ -1,0 +1,25 @@
+export const createJobInsertIntoIndex = `
+  mutation createJob($tdoId: ID!) {
+    createJob(input: {
+      targetId: $tdoId,
+      tasks: [{
+        engineId: "insert-into-index"
+      }]
+    }) {
+      id
+      tasks {
+        records {
+          id
+          jobId
+        }
+      }
+    }
+  }`;
+
+export const emitEvent = `
+  mutation emitEvent($input: EmitEvent!) {
+     emitEvent(input: $input) {
+       id
+     }
+   }
+`;

--- a/packages/veritone-widgets/src/redux/modules/mediaDetails/saga.js
+++ b/packages/veritone-widgets/src/redux/modules/mediaDetails/saga.js
@@ -23,10 +23,6 @@ import {
 } from 'lodash';
 import { helpers, modules } from 'veritone-redux-common';
 import {
-  pendingUserEdits,
-  ADD_DETECTED_FACE,
-  REMOVE_DETECTED_FACE,
-  CANCEL_FACE_EDITS,
   SAVE_FACE_EDITS_SUCCESS
 } from './faceEngineOutput';
 import {
@@ -59,6 +55,7 @@ import {
   REQUEST_SCHEMAS_FAILURE,
   CREATE_FILE_ASSET_SUCCESS,
   RESTORE_ORIGINAL_ENGINE_RESULTS,
+  RESTORE_ORIGINAL_ENGINE_RESULTS_SUCCESS,
   LOAD_TDO_SUCCESS,
   REFRESH_ENGINE_RUNS_SUCCESS,
   loadEngineCategoriesSuccess,
@@ -83,8 +80,12 @@ import {
   setEditButtonState,
   getSelectedEngineId,
   restoreOriginalEngineResultsFailure,
-  restoreOriginalEngineResultsSuccess
+  restoreOriginalEngineResultsSuccess,
+  insertIntoIndexFailure,
+  emitEntityUpdatedEventFailure
 } from '.';
+
+import * as gqlQuery from './queries';
 
 const tdoInfoQueryClause = `id
     details
@@ -886,6 +887,41 @@ function* watchRestoreOriginalEngineResults() {
   });
 }
 
+function* emitEntityUpdatedEvent(tdoId) {
+  const config = yield select(configModule.getConfig);
+  const { apiRoot, graphQLEndpoint } = config;
+  const graphQLUrl = `${apiRoot}/${graphQLEndpoint}`;
+  const token = yield select(authModule.selectSessionToken);
+
+  // TODO: remove hardcoded CMS applicationId when platform starts using orgId from the token
+  const input = {
+    eventName: 'EntityUpdated',
+    eventType: 'entity',
+    application: '8a37c1d0-3f3b-48d0-a84e-2b8e3646fbe5',
+    payload: `{ "recordingId": "${tdoId}" }`
+  };
+
+  try {
+    if (tdoId) {
+      const response = yield call(fetchGraphQLApi, {
+        endpoint: graphQLUrl,
+        query: gqlQuery.emitEvent,
+        variables: { input },
+        token
+      });
+      if (!get(response, 'data.emitEvent.id') || get(response, 'errors.length')) {
+        return yield put(
+          emitEntityUpdatedEventFailure('Failed to emit EntityUpdated event for saved results.')
+        );
+      }
+    }
+  } catch (error) {
+    return yield put(
+      emitEntityUpdatedEventFailure(`Failed to emit EntityUpdated event for saved results.`)
+    );
+  }
+}
+
 function* watchLoadEngineResultsComplete(widgetId) {
   yield takeEvery(engineResultsModule.FETCH_ENGINE_RESULTS_SUCCESS, function*(
     action
@@ -1149,20 +1185,6 @@ function* watchTranscriptStatus() {
   });
 }
 
-function* watchFaceEngineEntityUpdate(widgetId) {
-  yield takeEvery(
-    [ADD_DETECTED_FACE, REMOVE_DETECTED_FACE, CANCEL_FACE_EDITS],
-    function*(action) {
-      const selectedEngineId = yield select(getSelectedEngineId, widgetId);
-      const hasPendingFaceEdits = yield select(
-        pendingUserEdits,
-        selectedEngineId
-      );
-      yield put(toggleSaveMode(hasPendingFaceEdits));
-    }
-  );
-}
-
 function* watchCreateFileAssetSuccess() {
   yield takeEvery(
     action => action.type === CREATE_FILE_ASSET_SUCCESS,
@@ -1175,23 +1197,6 @@ function* watchCreateFileAssetSuccess() {
 }
 
 function* insertIntoIndexSaga(tdoId) {
-  const createJobQuery = `mutation createJob($tdoId: ID!) {
-    createJob(input: {
-      targetId: $tdoId,
-      tasks: [{
-        engineId: "insert-into-index"
-      }]
-    }) {
-      id
-      tasks {
-        records {
-          id
-          jobId
-        }
-      }
-    }
-  }`;
-
   const config = yield select(configModule.getConfig);
   const { apiRoot, graphQLEndpoint } = config;
   const graphQLUrl = `${apiRoot}/${graphQLEndpoint}`;
@@ -1202,22 +1207,18 @@ function* insertIntoIndexSaga(tdoId) {
   try {
     const response = yield call(fetchGraphQLApi, {
       endpoint: graphQLUrl,
-      query: createJobQuery,
+      query: gqlQuery.createJobInsertIntoIndex,
       variables: { tdoId: tdoId },
       token
     });
 
-    if (!get(response, 'data.createJob.id')) {
-      throw new Error('Failed to create insert-into-index task.');
-    }
-    if (
+    if (!get(response, 'data.createJob.id') ||
       isEmpty(get(response, 'data.createJob.tasks.records')) ||
-      !get(response, 'data.createJob.tasks.records[0].id')
-    ) {
-      throw new Error('Failed to create insert-into-index task.');
+      !get(response, 'data.createJob.tasks.records[0].id')) {
+      return yield put(insertIntoIndexFailure('Failed to create insert-into-index task.'));
     }
   } catch (error) {
-    // return yield put(insertIntoIndexFailure(widgetId, { error }));
+    return yield put(insertIntoIndexFailure('Failed to create insert-into-index task.'));
   }
 }
 
@@ -1320,6 +1321,24 @@ function* watchEditSuccess(widgetId) {
   );
 }
 
+function* watchSaveEntityUpdatesSuccess(widgetId) {
+  yield takeEvery(
+    [SAVE_FACE_EDITS_SUCCESS, RESTORE_ORIGINAL_ENGINE_RESULTS_SUCCESS],
+    function*() {
+      const selectedEngineCategory = yield select(
+        getSelectedEngineCategory,
+        widgetId
+      );
+      // Emit event for specific engine categories
+      if (selectedEngineCategory.categoryType !== 'face') {
+        return;
+      }
+      const tdo = yield select(getTdo, widgetId);
+      return yield call(emitEntityUpdatedEvent, tdo.id);
+    }
+  );
+}
+
 function* onMount(id, mediaId) {
   yield put(loadTdoRequest(id, mediaId));
   yield put(applicationModule.fetchApplications());
@@ -1335,13 +1354,13 @@ export default function* root({ id, mediaId, refreshIntervalMs }) {
     fork(watchLoadContentTemplates),
     fork(watchUpdateTdoContentTemplates),
     fork(watchTranscriptStatus),
-    fork(watchFaceEngineEntityUpdate, id),
     fork(watchCreateFileAssetSuccess),
     fork(watchLatestFetchEngineResultsStart, id),
     fork(watchLatestFetchEngineResultsEnd, id),
     fork(watchRestoreOriginalEngineResults),
     fork(watchToStartRefreshEngineRunsWithTimeout, id, refreshIntervalMs),
-    fork(watchEditSuccess, id, mediaId),
+    fork(watchEditSuccess, id),
+    fork(watchSaveEntityUpdatesSuccess, id),
     fork(onMount, id, mediaId)
   ]);
 }


### PR DESCRIPTION
Link to Ticket: https://steel-ventures.atlassian.net/browse/VTN-11610

Reviewers
---------
@ChrisPelletier @atb91590 

Purpose
-------
For Wazee integration when user edits entity in the face engine output, or resets edit to original - CMS should notify them.

What Changed
------------
In MDP added saga that'll call GQL to emit EntityUpdated even.
Decided to put that in MDP code because 1. potentially entities could be updated in different components: logo, object, face, etc. 2. This is Veritone+Wazee specific usecase, so probable smart components should not emit such event if reused outside of MDP.

How should we monitor this?
---------------------------
MDP save Face/Transcript, restore original should work as it worked before. For event check nsq logs on the environments.
Keep in mind that event first has to be created manually as described in https://steel-ventures.atlassian.net/browse/VTN-11513