### PR TITLE
VTN-10083 ignore special transcript words - do not render until there…

### DIFF
--- a/packages/veritone-react-common/src/components/TranscriptEngineOutput/SpeakerTranscriptContent/index.js
+++ b/packages/veritone-react-common/src/components/TranscriptEngineOutput/SpeakerTranscriptContent/index.js
@@ -201,8 +201,6 @@ export default class SpeakerTranscriptContent extends Component {
             if (overviewStatus && overviewStatus !== 'success') {
               saveOverviewData();
             }
-            snippetStatus = 'success';
-            overviewStatus = 'success';
 
             //---Get Correct Word---
             let selectedWord = '';
@@ -211,6 +209,17 @@ export default class SpeakerTranscriptContent extends Component {
             if (words.length > 0) {
               selectedWord = words[0].word;
             }
+
+            // ignore special words / states
+            if (selectedWord === '!silence' ||
+              selectedWord === '[noise]' ||
+              selectedWord === '<noise>'
+            ) {
+              return;
+            }
+
+            snippetStatus = 'success';
+            overviewStatus = 'success';
 
             // escape special characters to show in UI
             if (selectedWord) {

--- a/packages/veritone-react-common/src/components/TranscriptEngineOutput/TranscriptContent/index.js
+++ b/packages/veritone-react-common/src/components/TranscriptEngineOutput/TranscriptContent/index.js
@@ -165,8 +165,6 @@ export default class TranscriptContent extends Component {
             if (overviewStatus && overviewStatus !== 'success') {
               saveOverviewData();
             }
-            snippetStatus = 'success';
-            overviewStatus = 'success';
 
             //---Get Correct Word---
             let selectedWord = '';
@@ -175,6 +173,17 @@ export default class TranscriptContent extends Component {
             if (words.length > 0) {
               selectedWord = words[0].word;
             }
+
+            // ignore special words / states
+            if (selectedWord === '!silence' ||
+              selectedWord === '[noise]' ||
+              selectedWord === '<noise>'
+            ) {
+              return;
+            }
+
+            snippetStatus = 'success';
+            overviewStatus = 'success';
 
             // escape special characters to show in UI
             if (selectedWord) {


### PR DESCRIPTION
… is a requirement.

Link to Ticket: https://steel-ventures.atlassian.net/browse/VTN-10083

## Reviewers
@atb91590 @ChrisPelletier  


## Purpose
After migration to vlf - special words are being rendered. Ignore them as there is no design/requirement to present those.

## What Changed
Simply ignoring such snippets..
