### PR TITLE
Feature/vtn 11920 update bulk edit saga cherrypick

### DIFF
--- a/packages/veritone-widgets/src/redux/modules/mediaDetails/transcriptWidget/index.js
+++ b/packages/veritone-widgets/src/redux/modules/mediaDetails/transcriptWidget/index.js
@@ -508,15 +508,6 @@ const getPrimaryTranscriptAsset = (tdoId, dispatch, getState) => {
         primaryAsset(assetType: "transcript") {
           id
         }
-        assets(limit: 1000) {
-          records {
-            id
-            assetType
-            sourceData {
-              engineId
-            }
-          }
-        }
       }
     }`;
   return callGraphQLApi({
@@ -660,50 +651,67 @@ export const saveTranscriptEdit = (tdoId, selectedEngineId) => {
         });
       }
 
-      let getPrimaryTranscriptAssetResponse;
-      try {
-        getPrimaryTranscriptAssetResponse = await getPrimaryTranscriptAsset(
-          tdoId,
-          dispatch,
-          getState
-        );
-      } catch (e) {
-        console.error(e);
-        dispatch({
-          type: SAVE_TRANSCRIPT_EDITS_FAILURE,
-          payload: {
-            error: 'Failed to get primary transcript asset.'
-          }
-        });
-        return;
-      }
-
       let originalTranscriptAssetId;
       // order of original transcript preference:
       // vtn-standard => v-vlf => primary transcript
-      const assets = get(getPrimaryTranscriptAssetResponse,
-          'temporalDataObject.assets.records', []);
-
-      const vlfAssets = assets.filter(asset => asset.assetType === 'v-vlf');
-      const vlfAssetToUse = find(vlfAssets, ['sourceData.engineId', selectedEngineId]);
-
-      const vtnStandardAssets = assets.filter(asset => asset.assetType === 'vtn-standard');
+      const vtnStandardAssetsResponse = await fetchAssets( 
+        tdoId,  
+        'vtn-standard', 
+        dispatch, 
+        getState  
+      );
+      const vtnStandardAssets = get(
+        vtnStandardAssetsResponse,
+        'temporalDataObject.assets.records',
+        []
+      );
       const vtnStandardAssetToUse = find(vtnStandardAssets, ['sourceData.engineId', selectedEngineId]);
 
       if (vtnStandardAssetToUse) {
         originalTranscriptAssetId = vtnStandardAssetToUse.id;
-      } else if (vlfAssetToUse) {
-        originalTranscriptAssetId = vlfAssetToUse.id;
-      } else if (
-        get(
-          getPrimaryTranscriptAssetResponse,
-          'temporalDataObject.primaryAsset.id'
-        )
-      ) {
-        originalTranscriptAssetId = get(
-          getPrimaryTranscriptAssetResponse,
-          'temporalDataObject.primaryAsset.id'
+      } else {
+        // vtn-standard doesn't exist, try for v-vlf
+        const vlfAssetsResponse = await fetchAssets( 
+          tdoId,  
+          'v-vlf', 
+          dispatch, 
+          getState  
         );
+        const vlfAssets = get(
+          vlfAssetsResponse,
+          'temporalDataObject.assets.records',
+          []
+        );
+        const vlfAssetToUse = find(vlfAssets, ['sourceData.engineId', selectedEngineId]);
+        if (vlfAssetToUse) {
+          originalTranscriptAssetId = vlfAssetToUse.id;  
+        } else {
+          // vlf doens't exist, try for primary transcript (ttml)
+          let getPrimaryTranscriptAssetResponse;
+          try {
+            getPrimaryTranscriptAssetResponse = await getPrimaryTranscriptAsset(
+              tdoId,
+              dispatch,
+              getState
+            );
+          } catch (e) {
+            console.error(e);
+            dispatch({
+              type: SAVE_TRANSCRIPT_EDITS_FAILURE,
+              payload: {
+                error: 'Failed to get primary transcript asset.'
+              }
+            });
+            return;
+          }
+          const primaryAssetId = get(
+            getPrimaryTranscriptAssetResponse,
+            'temporalDataObject.primaryAsset.id'
+          );
+          if (primaryAssetId) {
+            originalTranscriptAssetId = primaryAssetId;
+          }
+        }
       }
 
       if (!originalTranscriptAssetId) {

--- a/packages/veritone-widgets/src/redux/modules/mediaDetails/transcriptWidget/index.js
+++ b/packages/veritone-widgets/src/redux/modules/mediaDetails/transcriptWidget/index.js
@@ -579,7 +579,7 @@ const runBulkEditJob = (
           originalTranscriptAssetId: "${originalTranscriptAssetId}",
           temporaryBulkEditAssetId: "${bulkTextAssetId}",
           originalEngineId: "${engineId}",
-          saveTtmlToVtnStandard: true
+          saveToVtnStandard: true
         }
       },
       {

--- a/packages/veritone-widgets/src/redux/modules/mediaDetails/transcriptWidget/index.js
+++ b/packages/veritone-widgets/src/redux/modules/mediaDetails/transcriptWidget/index.js
@@ -679,8 +679,8 @@ export const saveTranscriptEdit = (tdoId, selectedEngineId) => {
       }
 
       let originalTranscriptAssetId;
-      // use vlf instead of the primary transcript asset if it exists for the current engine
-      // if not found 'transcript' ttml asset - try to find original 'vtn-standard' asset for selected transcript engine
+      // order of original transcript preference:
+      // vtn-standard => v-vlf => primary transcript
       const assets = get(getPrimaryTranscriptAssetResponse,
           'temporalDataObject.assets.records', []);
 


### PR DESCRIPTION
Link to Ticket: https://steel-ventures.atlassian.net/browse/VTN-11920

Reviewers
---------
@atb91590 @ChrisPelletier @jordanheadley 

Purpose
-------
Use vlf as original asset to run levenstein if no vtn found.

What Changed
------------
Cherrypicked commits https://github.com/veritone/veritone-sdk/pull/284/commits 
NOTE: task-bulk-edit was updated to ignore '!silence', '[noise]' that would screw up the result. 