### PR TITLE
fix bug: VTN-7652-CMS-file-download-not-functioning-properly

### DIFF
--- a/packages/veritone-widgets/src/widgets/MediaDetails/index.js
+++ b/packages/veritone-widgets/src/widgets/MediaDetails/index.js
@@ -664,7 +664,6 @@ class MediaDetailsWidget extends React.Component {
     const element = document.createElement('a');
     element.href = get(this.props.tdo, 'primaryAsset.signedUri', '');
     element.download = get(this.props, 'tdo.details.veritoneFile.filename');
-    element.target = '_blank';
     element.click();
   };
 


### PR DESCRIPTION
Link to ticket:
https://steel-ventures.atlassian.net/browse/VTN-7652
Reviewer:
@atb91590 
What changed:
-------------
Remove `target="_blank"` to ignore open new tab when downloading the file from CMS.