### PR TITLE
account for azure uploads

### DIFF
--- a/packages/veritone-widgets/src/shared/uploadFilesChannel.js
+++ b/packages/veritone-widgets/src/shared/uploadFilesChannel.js
@@ -48,7 +48,7 @@ export default function uploadFilesChannel(
     if (readyState === XMLHttpRequest.DONE) {
       remainingFiles -= 1;
 
-      if (status === 200) {
+      if (status >= 200 && status < 300) {
         chan.put({ success: true, file, descriptor });
       } else {
         onStatusCodeFailure(file, descriptor);
@@ -80,6 +80,8 @@ export default function uploadFilesChannel(
     // xhr.upload.addEventListener('abort', onFailure.bind(null, file, descriptor));
 
     xhr.open(method, descriptor.url, true);
+    // Need this header for azure
+    xhr.setRequestHeader('x-ms-blob-type', 'BlockBlob');
     xhr.send(file);
   });
 


### PR DESCRIPTION
this change is needed for storage on azure blobs. adding this new header has no affect on our existing s3 use case.

It has been tested with both s3 buckets and azure blobs. Works perfectly fine.

After this merge has been made, we need to:
- increment widgets semvar
- publish this package to npm
- update all applications using veritone-widgets master (i'll take care of this part)