### PR TITLE
Feature/VTN-20277 Non Modal File Picker

### DIFF
--- a/packages/veritone-react-common/CHANGELOG.md
+++ b/packages/veritone-react-common/CHANGELOG.md
@@ -190,3 +190,9 @@
 ## 7.1.0
 * Added a radio selection button
 
+## 7.2.0
+* Changes to file picker:
+  * Added a non-modal style so it can sit flat in a modal, so we don’t have a modal on top of a modal
+  * Added maxFiles limit. When used, it shows {numberOfFilesToUpload} / {maxFiles}.
+  * Allow the upload button to be set via props, in case we want it to say “Benchmark” or “Process” as the next step instead.
+  * Better error messages when >1 file when multiple is false, better error messages when multiple is true, and maxFiles limit is set.

--- a/packages/veritone-react-common/package.json
+++ b/packages/veritone-react-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritone-react-common",
-  "version": "7.1.0",
+  "version": "7.2.0",
   "main": "dist/bundle-cjs.js",
   "module": "dist/bundle-es.js",
   "jsnext:main": "dist/bundle-es.js",

--- a/packages/veritone-react-common/src/components/FilePicker/FilePickerFooter/index.js
+++ b/packages/veritone-react-common/src/components/FilePicker/FilePickerFooter/index.js
@@ -1,17 +1,18 @@
 import React, { Component } from 'react';
 import Button from '@material-ui/core/Button';
-import { number, func } from 'prop-types';
+import { bool, func, string } from 'prop-types';
 import styles from './styles.scss';
 
 class FilePickerFooter extends Component {
   static propTypes = {
-    fileCount: number,
+    disabled: bool,
     onCancel: func,
-    onSubmit: func
+    onSubmit: func,
+    title: string
   };
 
   static defaultProps = {
-    fileCount: 0
+    title: 'Upload'
   };
 
   render() {
@@ -20,11 +21,11 @@ class FilePickerFooter extends Component {
         <Button onClick={this.props.onCancel}>Cancel</Button>
         <Button
           variant="raised"
-          disabled={this.props.fileCount < 1}
+          disabled={this.props.disabled}
           color="primary"
           onClick={this.props.onSubmit}
         >
-          Upload
+          {this.props.title}
         </Button>
       </div>
     );

--- a/packages/veritone-react-common/src/components/FilePicker/FilePickerHeader/FilePickerFlatHeader.js
+++ b/packages/veritone-react-common/src/components/FilePicker/FilePickerHeader/FilePickerFlatHeader.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { string, number } from 'prop-types';
+
+import Typography from '@material-ui/core/Typography';
+
+import styles from './styles.scss';
+
+const FilePickerFlatHeader = ({ title, fileCount, maxFiles }) => {
+  return (
+    <div className={styles.filePickerFlatHeader}>
+      <Typography variant={'title'}>
+        {title}
+        &nbsp;<span className={styles.count}>
+          {fileCount}/{maxFiles}
+        </span>
+      </Typography>
+    </div>
+  );
+};
+
+FilePickerFlatHeader.propTypes = {
+  title: string,
+  fileCount: number,
+  maxFiles: number
+};
+
+FilePickerFlatHeader.defaultProps = {
+  title: 'Uploaded',
+  fileCount: 0,
+  maxFiles: 1
+};
+
+export default FilePickerFlatHeader;

--- a/packages/veritone-react-common/src/components/FilePicker/FilePickerHeader/index.js
+++ b/packages/veritone-react-common/src/components/FilePicker/FilePickerHeader/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
 import IconButton from '@material-ui/core/IconButton';
-import { string, func, bool } from 'prop-types';
+import { string, func, bool, number } from 'prop-types';
 
 import styles from './styles.scss';
 
@@ -12,7 +12,10 @@ class FilePickerHeader extends Component {
     onSelectTab: func,
     onClose: func,
     allowUrlUpload: bool,
-    title: string
+    multiple: bool,
+    title: string,
+    fileCount: number,
+    maxFiles: number
   };
 
   static defaultProps = {
@@ -26,15 +29,26 @@ class FilePickerHeader extends Component {
   render() {
     return (
       <div className={styles.filePickerHeader}>
-        <span className={styles.filePickerTitle}>{this.props.title}</span>
-        <IconButton
-          classes={{
-            root: styles.filePickerCloseButton
-          }}
-          onClick={this.props.onClose}
-        >
-          <i className="icon-close-exit" />
-        </IconButton>
+        <span className={styles.filePickerTitle}>
+          {this.props.title}
+
+          {this.props.multiple &&
+            this.props.maxFiles && (
+              <span className={styles.count}>
+                {this.props.fileCount} / {this.props.maxFiles}
+              </span>
+            )}
+        </span>
+        {this.props.onClose && (
+          <IconButton
+            classes={{
+              root: styles.filePickerCloseButton
+            }}
+            onClick={this.props.onClose}
+          >
+            <i className="icon-close-exit" />
+          </IconButton>
+        )}
         <Tabs
           value={this.props.selectedTab}
           indicatorColor="primary"

--- a/packages/veritone-react-common/src/components/FilePicker/FilePickerHeader/styles.scss
+++ b/packages/veritone-react-common/src/components/FilePicker/FilePickerHeader/styles.scss
@@ -21,3 +21,17 @@
   top: 8px;
   right: 5px;
 }
+
+.filePickerFlatHeader {
+  padding: 20px;
+  padding-bottom: 0;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.count {
+  padding-left: 0.5em;
+  color: $semi-black;
+  font-size: 0.75em;
+}

--- a/packages/veritone-react-common/src/components/FilePicker/FileUploader/index.js
+++ b/packages/veritone-react-common/src/components/FilePicker/FileUploader/index.js
@@ -7,6 +7,7 @@ import mime from 'mime-types';
 import { NativeTypes } from 'react-dnd-html5-backend';
 const { FILE } = NativeTypes;
 
+import cx from 'classnames';
 import styles from './styles.scss';
 
 const boxTarget = {
@@ -59,6 +60,7 @@ class FileUploader extends Component {
   static propTypes = {
     acceptedFileTypes: arrayOf(string),
     onFilesSelected: func.isRequired,
+    useFlatStyle: bool,
     // eslint-disable-next-line react/no-unused-prop-types
     onFilesRejected: func,
     isOver: bool.isRequired,
@@ -99,7 +101,12 @@ class FileUploader extends Component {
       : 'Drag & Drop file(s) to upload, or';
 
     return connectDropTarget(
-      <div className={styles.fileUploader}>
+      <div
+        className={cx([
+          styles.fileUploader,
+          { [styles.flat]: this.props.useFlatStyle }
+        ])}
+      >
         <span className={styles.fileUploadIcon}>
           <i className="icon-cloud_upload" />
         </span>

--- a/packages/veritone-react-common/src/components/FilePicker/FileUploader/styles.scss
+++ b/packages/veritone-react-common/src/components/FilePicker/FileUploader/styles.scss
@@ -14,6 +14,10 @@
   position: relative;
 }
 
+.flat {
+  background-color: $fullWhite !important;
+}
+
 .fileUploadIcon {
   color: #9a9a9a;
 

--- a/packages/veritone-react-common/src/components/FilePicker/index.js
+++ b/packages/veritone-react-common/src/components/FilePicker/index.js
@@ -11,6 +11,7 @@ import FilePickerFooter from './FilePickerFooter';
 import UrlUploader from './UrlUploader';
 import DragDropContext from './DragDropContext';
 import styles from './styles.scss';
+import FilePickerFlatHeader from './FilePickerHeader/FilePickerFlatHeader';
 
 class FilePicker extends Component {
   static propTypes = {
@@ -20,7 +21,11 @@ class FilePicker extends Component {
     height: number,
     onPickFiles: func.isRequired,
     onRequestClose: func.isRequired,
-    allowUrlUpload: bool
+    allowUrlUpload: bool,
+    maxFiles: number,
+    title: string,
+    tooManyFilesErrorMessage: func,
+    oneFileOnlyErrorMessage: string
   };
 
   static defaultProps = {
@@ -28,7 +33,11 @@ class FilePicker extends Component {
     width: 600,
     accept: [],
     multiple: false,
-    allowUrlUpload: true
+    allowUrlUpload: true,
+    title: 'File Picker',
+    tooManyFilesErrorMessage: maxFiles =>
+      `You can select up to and including ${maxFiles} files. Please remove any unnecessary files.`,
+    oneFileOnlyErrorMessage: `Only one file can be selected at a time`
   };
 
   state = {
@@ -49,19 +58,28 @@ class FilePicker extends Component {
     const files = isArray(fileOrFiles) ? fileOrFiles : [fileOrFiles];
 
     if (this.props.multiple) {
+      if (
+        this.props.maxFiles &&
+        (this.state.files.length >= this.props.maxFiles ||
+          files.length > this.props.maxFiles)
+      ) {
+        // if a file was already staged, or user tried to add more than one file
+        this.setState({
+          errorMessage: this.props.tooManyFilesErrorMessage(this.props.maxFiles)
+        });
+      } else {
+        this.clearErrorMessage();
+      }
+
       this.setState(state => ({
         files: [...state.files, ...files]
       }));
-
-      return this.clearErrorMessage();
     } else {
       // single mode
       if (this.state.files.length >= 1 || files.length > 1) {
         // if a file was already staged, or user tried to add more than one file
         this.setState({
-          errorMessage:
-            'Only a single file is supported for this input;' +
-            ' the first selected file has been staged.'
+          errorMessage: this.props.oneFileOnlyErrorMessage
         });
       } else {
         this.clearErrorMessage();
@@ -113,6 +131,17 @@ class FilePicker extends Component {
     });
   }
 
+  disableNextStep() {
+    if (this.props.multiple && this.props.maxFiles) {
+      return (
+        this.state.files.length > this.props.maxFiles ||
+        this.state.files.length === 0
+      );
+    } else {
+      return this.state.files.length === 0;
+    }
+  }
+
   render() {
     const acceptedFileTypes = (isString(this.props.accept)
       ? [this.props.accept]
@@ -121,30 +150,49 @@ class FilePicker extends Component {
 
     return (
       <Paper
-        classes={{
-          root: styles.filePickerPaperOverride
-        }}
+        classes={
+          this.props.onRequestClose && {
+            root: styles.filePickerPaperOverride
+          }
+        }
         style={{
           height: this.props.height,
           width: this.props.width
         }}
       >
         <div
-          className={styles.filePicker}
+          className={
+            this.props.onRequestClose
+              ? styles.filePicker
+              : styles.filePickerNonModal
+          }
           style={{
             height: '100%'
           }}
         >
-          <FilePickerHeader
-            selectedTab={this.state.selectedTab}
-            onSelectTab={this.handleTabChange}
-            onClose={this.handleCloseModal}
-            allowUrlUpload={this.props.allowUrlUpload}
-          />
+          {this.props.onRequestClose ? (
+            <FilePickerHeader
+              selectedTab={this.state.selectedTab}
+              onSelectTab={this.handleTabChange}
+              onClose={this.handleCloseModal}
+              allowUrlUpload={this.props.allowUrlUpload}
+              title={this.props.title}
+              fileCount={this.state.files.length}
+              maxFiles={this.props.maxFiles}
+              multiple={this.props.multiple}
+            />
+          ) : (
+            <FilePickerFlatHeader
+              title={this.props.title}
+              fileCount={this.state.files.length}
+              maxFiles={this.props.maxFiles}
+            />
+          )}
 
           {this.state.selectedTab === 'upload' && (
             <div className={styles.filePickerBody}>
               <FileUploader
+                useFlatStyle={!this.props.onRequestClose}
                 onFilesSelected={this.handleFilesSelected}
                 onFilesRejected={this.handleFilesRejected}
                 acceptedFileTypes={acceptedFileTypes}
@@ -168,11 +216,13 @@ class FilePicker extends Component {
             </div>
           )}
           <div className={styles.errorMessage}>{this.state.errorMessage}</div>
-          <FilePickerFooter
-            onCancel={this.handleCloseModal}
-            onSubmit={this.handlePickFiles}
-            fileCount={this.state.files.length}
-          />
+          {this.props.onRequestClose && (
+            <FilePickerFooter
+              onCancel={this.handleCloseModal}
+              onSubmit={this.handlePickFiles}
+              disabled={this.disableNextStep()}
+            />
+          )}
         </div>
       </Paper>
     );

--- a/packages/veritone-react-common/src/components/FilePicker/story.js
+++ b/packages/veritone-react-common/src/components/FilePicker/story.js
@@ -19,4 +19,47 @@ storiesOf('FilePicker', module)
       onPickFiles={action('upload files')}
       onRequestClose={action('close modal')}
     />
+  ))
+  .add('With Multiple', () => (
+    <FilePicker
+      accept={['image/svg+xml', '.png', '.jpg']}
+      height={800}
+      width={800}
+      multiple
+      maxFiles={2}
+      onPickFiles={action('upload files')}
+      onRequestClose={action('close modal')}
+    />
+  ))
+  .add('Flat on a page', () => (
+    <FilePicker
+      accept={['image/svg+xml', '.png', '.jpg']}
+      height={800}
+      width={800}
+      onPickFiles={action('upload files')}
+      multiple
+      allowUrlUpload={false}
+    />
+  ))
+  .add('Flat on a page with max file limit', () => (
+    <FilePicker
+      accept={['image/svg+xml', '.png', '.jpg']}
+      height={800}
+      width={800}
+      onPickFiles={action('upload files')}
+      multiple
+      maxFiles={5}
+      allowUrlUpload={false}
+    />
+  ))
+  .add('Flat with scrollbars', () => (
+    <div style={{ height: '500px', width: '600px' }}>
+      <FilePicker
+        accept={['image/svg+xml', '.png', '.jpg']}
+        height={'100%'}
+        multiple
+        onPickFiles={action('upload files')}
+        allowUrlUpload={false}
+      />
+    </div>
   ));

--- a/packages/veritone-react-common/src/components/FilePicker/styles.scss
+++ b/packages/veritone-react-common/src/components/FilePicker/styles.scss
@@ -7,6 +7,12 @@
   max-width: 100%;
 }
 
+.filePickerNonModal {
+  display: flex;
+  flex-direction: column;
+  background-color: white;
+}
+
 .filePickerPaperOverride {
   max-width: 100% !important;
   max-height: 100% !important;
@@ -24,4 +30,5 @@
 .errorMessage {
   text-align: center;
   color: red;
+  padding-bottom: 0.25em;
 }


### PR DESCRIPTION
  * Added a non-modal style so it can sit flat in a modal, so we don’t have a modal on top of a modal
  * Added maxFiles limit. When used, it shows {numberOfFilesToUpload} / {maxFiles}.
  * Allow the upload button to be set via props, in case we want it to say “Benchmark” or “Process” as the next step instead.
  * Better error messages when >1 file when multiple is false, better error messages when multiple is true, and maxFiles limit is set.