### PR TITLE
Pass timezone instead of showTimezone

### DIFF
--- a/packages/veritone-react-common/src/components/formComponents/DateTimePicker.js
+++ b/packages/veritone-react-common/src/components/formComponents/DateTimePicker.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Today from '@material-ui/icons/Today';
 import dateFns from 'date-fns';
 import TextField from '@material-ui/core/TextField';
-import { instanceOf, func, shape, string, bool } from 'prop-types';
+import { instanceOf, func, shape, string, bool, oneOfType } from 'prop-types';
 
 import styles from './styles/dateTimePicker.scss';
 
@@ -11,7 +11,7 @@ export default class DateTimePicker extends React.Component {
     min: instanceOf(Date),
     max: instanceOf(Date),
     showIcon: bool,
-    showTimezone: bool,
+    timeZone: oneOfType([string, bool]),
     input: shape({
       value: instanceOf(Date).isRequired,
       onChange: func
@@ -42,6 +42,14 @@ export default class DateTimePicker extends React.Component {
 
   render() {
     const { input, min, max, ...rest } = this.props;
+    let { timeZone } = this.props;
+
+    // some components are not passing timezone, so we need to find it out
+    // eslint-disable-next-line lodash/prefer-lodash-typecheck
+    if (typeof timeZone === 'boolean' && timeZone) {
+      timeZone = getTimeZone(input.value);
+    }
+
     return (
       <div className={styles.container}>
         {this.props.showIcon && <Today className={styles.todayIcon} />}
@@ -59,9 +67,7 @@ export default class DateTimePicker extends React.Component {
           onChange={this.handleTimeChange}
           {...rest}
         />
-        {this.props.showTimezone && (
-          <TimeZoneField value={getTimeZone(input.value)} {...rest} />
-        )}
+        {timeZone && <TimeZoneField value={timeZone} {...rest} />}
       </div>
     );
   }

--- a/packages/veritone-react-common/src/components/formComponents/TimeRangePicker.js
+++ b/packages/veritone-react-common/src/components/formComponents/TimeRangePicker.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { string, func, shape, bool } from 'prop-types';
+import { string, func, shape, bool, oneOfType } from 'prop-types';
 import dateFns from 'date-fns';
 import TextField from '@material-ui/core/TextField';
 
@@ -15,7 +15,8 @@ export default class TimeRangePicker extends React.Component {
       }).isRequired,
       onChange: func.isRequired
     }).isRequired,
-    readOnly: bool
+    readOnly: bool,
+    timeZone: oneOfType([string, bool])
   };
 
   handleChangeStart = ({ target: { value } }) => {
@@ -50,6 +51,14 @@ export default class TimeRangePicker extends React.Component {
   }
 
   render() {
+    let { timeZone } = this.props;
+
+    // some components are not passing timezone, so we need to find it out
+    // eslint-disable-next-line lodash/prefer-lodash-typecheck
+    if (typeof timeZone === 'boolean' && timeZone) {
+      timeZone = this.props.input.value.timeZone || this.getTimeZone();
+    }
+
     return (
       <div className={styles.container}>
         <TimeSelector
@@ -57,29 +66,33 @@ export default class TimeRangePicker extends React.Component {
           onChange={this.handleChangeStart}
           readOnly={this.props.readOnly}
         />
-        <TextField
-          className={styles.dateTimeTZ}
-          value={this.props.input.value.timeZone || this.getTimeZone()}
-          InputProps={{
-            disableUnderline: true
-          }}
-          disabled
-        />
+        {timeZone && (
+          <TextField
+            className={styles.dateTimeTZ}
+            value={timeZone}
+            InputProps={{
+              disableUnderline: true
+            }}
+            disabled
+          />
+        )}
         <span className={styles.separator}>to</span>
         <TimeSelector
           value={this.props.input.value.end}
           onChange={this.handleChangeEnd}
           readOnly={this.props.readOnly}
         />
-        <TextField
-          className={styles.dateTimeTZ}
-          value={this.props.input.value.timeZone || this.getTimeZone()}
-          InputProps={{
-            disableUnderline: true,
-            readOnly: this.props.readOnly
-          }}
-          disabled
-        />
+        {timeZone && (
+          <TextField
+            className={styles.dateTimeTZ}
+            value={timeZone}
+            InputProps={{
+              disableUnderline: true,
+              readOnly: this.props.readOnly
+            }}
+            disabled
+          />
+        )}
       </div>
     );
   }

--- a/packages/veritone-react-common/src/components/formComponents/story.js
+++ b/packages/veritone-react-common/src/components/formComponents/story.js
@@ -377,7 +377,7 @@ storiesOf('Form Components', module)
             component={DateTimePicker}
             name="dateTimeTimezone"
             clearable
-            showTimezone
+            timeZone
           />
         </StoryForm>
       </Provider>


### PR DESCRIPTION
Pass timezone instead of showTimezone. We can override timezone this way. `true` could be passed for showing browser's default time zone. 