### PR TITLE
feature/vtn-27962 Improve header bar

### DIFF
--- a/packages/veritone-react-common/src/components/AppBar/index.js
+++ b/packages/veritone-react-common/src/components/AppBar/index.js
@@ -193,16 +193,20 @@ export default class AppBar extends React.Component {
               {//Custom Controllers (Copy over from the previous app bar version)
               rightActions &&
                 rightActions.length > 0 && (
-                  <div className={styles['iconGroup']}>
-                    {rightActions.map(({ label, onClick }) => (
+                  <div
+                    className={classNames(styles['iconGroup'], styles.noSelect)}
+                  >
+                    {rightActions.map(({ label, onClick, isActive }) => (
                       <div className={styles['iconGroup__icon']} key={label}>
-                        <a
-                          href="#"
+                        <span
                           onClick={onClick}
-                          className={styles['rightAction-label']}
+                          className={classNames(
+                            styles['rightAction-label'],
+                            isActive ? styles.active : styles.passive
+                          )}
                         >
                           {label}
-                        </a>
+                        </span>
                       </div>
                     ))}
                   </div>

--- a/packages/veritone-react-common/src/components/AppBar/index.js
+++ b/packages/veritone-react-common/src/components/AppBar/index.js
@@ -163,12 +163,11 @@ export default class AppBar extends React.Component {
         >
           {logo && <img src={logoSrc} draggable="false" />}
         </div>
-        <div
-          className={styles.content}
-          style={{ color: titleColor }}
-          onClick={this.goHome}
-        >
-          <div className={classNames(styles.left, styles.noSelect)}>
+        <div className={styles.content} style={{ color: titleColor }}>
+          <div
+            className={classNames(styles.left, styles.noSelect)}
+            onClick={this.goHome}
+          >
             {appLogoSrc ? (
               <img
                 className={styles.appLogo}

--- a/packages/veritone-react-common/src/components/AppBar/index.js
+++ b/packages/veritone-react-common/src/components/AppBar/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Paper from '@material-ui/core/Paper';
 import IconButton from '@material-ui/core/IconButton';
 import CloseIcon from '@material-ui/icons/Close';
+import classNames from 'classnames';
 
 import {
   objectOf,
@@ -71,10 +72,14 @@ export default class AppBar extends React.Component {
     searchBar: oneOfType([bool, element]),
     searchBarJustification: oneOf(['flex-start', 'center', 'flex-end']),
     searchBarLeftMargin: oneOfType([string, number]),
-    searchBarAlignSelf:
-      oneOf([
-        'baseline', 'auto', 'inherit', 'center', 'flex-start', 'flex-end'
-      ]),
+    searchBarAlignSelf: oneOf([
+      'baseline',
+      'auto',
+      'inherit',
+      'center',
+      'flex-start',
+      'flex-end'
+    ]),
     zIndex: number
   };
   static defaultProps = {
@@ -97,6 +102,10 @@ export default class AppBar extends React.Component {
 
   handleRefresh = () => {
     this.props.fetchEnabledApps();
+  };
+
+  goHome = () => {
+    window.location.pathname = '/';
   };
 
   render() {
@@ -150,11 +159,16 @@ export default class AppBar extends React.Component {
         <div
           className={styles.logo}
           style={{ backgroundColor: logoBackgroundColor }}
+          onClick={this.goHome}
         >
           {logo && <img src={logoSrc} draggable="false" />}
         </div>
-        <div className={styles.content} style={{ color: titleColor }}>
-          <div className={styles.left}>
+        <div
+          className={styles.content}
+          style={{ color: titleColor }}
+          onClick={this.goHome}
+        >
+          <div className={classNames(styles.left, styles.noSelect)}>
             {appLogoSrc ? (
               <img
                 className={styles.appLogo}

--- a/packages/veritone-react-common/src/components/AppBar/styles.scss
+++ b/packages/veritone-react-common/src/components/AppBar/styles.scss
@@ -79,14 +79,21 @@
 }
 
 .rightAction-label {
-  @include mui-text('caption');
-
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 16px;
   text-decoration: none;
   color: white;
-  //margin: 0;
-  opacity: 0.87;
 }
 
-.noSelect{
+.noSelect {
   user-select: none;
+}
+
+.active {
+  opacity: 1;
+}
+
+.passive {
+  opacity: 0.8;
 }

--- a/packages/veritone-react-common/src/components/AppBar/styles.scss
+++ b/packages/veritone-react-common/src/components/AppBar/styles.scss
@@ -86,3 +86,7 @@
   //margin: 0;
   opacity: 0.87;
 }
+
+.noSelect{
+  user-select: none;
+}

--- a/packages/veritone-react-common/src/components/ProfileMenu/index.js
+++ b/packages/veritone-react-common/src/components/ProfileMenu/index.js
@@ -6,6 +6,8 @@ import Avatar from '@material-ui/core/Avatar';
 import Tooltip from '@material-ui/core/Tooltip';
 import { string, func, shape, arrayOf, element } from 'prop-types';
 
+import classNames from 'classnames';
+
 import InnerProfileMenu from './InnerProfileMenu';
 import styles from './styles.scss';
 
@@ -60,7 +62,7 @@ export default class ProfileMenu extends React.Component {
       <div>
         <Tooltip title={this.props.tooltipTitle || ''} disableFocusListener>
           <IconButton
-            className={this.props.className}
+            className={classNames(this.props.className, styles.center)}
             onClick={this.openMenu}
             data-veritone-element="profile-menu-button"
           >

--- a/packages/veritone-react-common/src/components/ProfileMenu/styles.scss
+++ b/packages/veritone-react-common/src/components/ProfileMenu/styles.scss
@@ -49,3 +49,9 @@
     }
   }
 }
+
+.center{
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}


### PR DESCRIPTION
https://steel-ventures.atlassian.net/browse/VTN-27962

I might have combined some of these into same commit;


Tool Tip hover on app switcher and user profile is too small. Should be 12px font size

Clicking the application name should always take you home

Using the application Switcher and selecting an application causes the user to be sent to the login screen

Edit Profile Button Color should be #0091EA

Increase Font Size of “Search Result” and “Watchlist” to 14

Remove Underline on Hover of “Search Result” and “ Watchlist”

Select Option of “Search Result” or “Watchlist” Should be #FFFFFF and unselected option should be Opacity 80%

Hover state of User profile background is offset and not centered to avatar