### PR TITLE
VTN-26012 Remove text indexing from content classification real world example

### DIFF
--- a/packages/veritone-json-schemas/schemas/vtn-standard/concept/examples/include-text-indexing.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/concept/examples/include-text-indexing.json
@@ -15,7 +15,10 @@
           "@id": "http://cv.iptc.org/newscodes/subjectcode/04006000",
           "confidence": 0.897
         }
-      ]
+      ],
+      "page": 1,
+      "paragraph": 2,
+      "sentence": 3
     }
   ]
 }


### PR DESCRIPTION
https://steel-ventures.atlassian.net/browse/VTN-26012

In the "real world" content classification engines don't usually include
text indexing information for individual insights because they usually
cover the content classification for the document as a whole.

But it's fine if we continue supporting it, so I've moved it to a
secondary valid example.
(The "real world" example is used in our docs)