### PR TITLE
VTN-37196: Fix close help modal on Chat With Support click.

### DIFF
--- a/packages/veritone-react-common/CHANGELOG.md
+++ b/packages/veritone-react-common/CHANGELOG.md
@@ -321,3 +321,6 @@
 
 ## 10.0.4
 * fix EditProfileButton's text color to white
+
+## 10.0.5
+* Fix: Close help modal on Chat With Support click

--- a/packages/veritone-react-common/package.json
+++ b/packages/veritone-react-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veritone-react-common",
-  "version": "10.0.4",
+  "version": "10.0.5",
   "main": "dist/bundle-cjs.js",
   "module": "dist/bundle-es.js",
   "jsnext:main": "dist/bundle-es.js",

--- a/packages/veritone-react-common/src/components/Help/index.js
+++ b/packages/veritone-react-common/src/components/Help/index.js
@@ -65,6 +65,7 @@ class Help extends React.Component {
   }
 
   openChatWindow = event => {
+    this.setState({ anchorEl: null });
     this.props.supportCallback && this.props.supportCallback();
     window.Intercom && window.Intercom('show');
   }


### PR DESCRIPTION
Link to ticket: https://steel-ventures.atlassian.net/browse/VTN-37196
 
- Set anchorEl to null when user clicks openChatWindow()
 - update CHANGELOG
 - update veritone-react-common version to 10.0.5

@MmtBkn Once this PR has been approved and merged, could you please assist us with the deployment process for this fix? I would appreciate it! 

FYI @mikennedy16 