### PR TITLE
GLC-1687 generate query for sentiment search

### DIFF
--- a/packages/veritone-csp-generator/src/index.js
+++ b/packages/veritone-csp-generator/src/index.js
@@ -249,14 +249,26 @@ const ObjectConditionGenerator = modalState => {
 };
 
 const SentimentConditionGenerator = modalState => {
+  let positive = '0.5';
+  let negative = '0.5';
+  if (modalState.customizedSearch && modalState.customizedSearch.sentiment) {
+    const sentiment = modalState.customizedSearch.sentiment;
+    if (sentiment.positive) {
+      positive = sentiment.positive;
+    }
+    if (sentiment.negative) {
+      negative = sentiment.negative;
+    }
+  }
+
   const sentimentOperator = {
     operator: 'range',
-    field: 'sentiment-veritone.series.score'
+    field: 'sentiment.sentiment.positiveValue'
   };
   if (modalState.search == 'positive') {
-    sentimentOperator.gte = '0.5';
+    sentimentOperator.gte = positive;
   } else {
-    sentimentOperator.lt = '0.5';
+    sentimentOperator.lt = negative;
   }
   return sentimentOperator;
 };
@@ -587,6 +599,7 @@ const generateQueryCondition = node => {
     && node.engineCategoryId
     && typeof engineCategoryMapping[node.engineCategoryId] === 'function'
   ) {
+    node.state.customizedSearch = node.customizedSearch;
     const newCondition = engineCategoryMapping[node.engineCategoryId](node.state);
     return newCondition;
   } else {


### PR DESCRIPTION
added following
1. query for sentiment search
2. make the sentiment score to be passed in. Default to positive 0.5 and negative 0.5 if no value passed in.
e.g. in onSearch function, add following:

csp.customizedSearch =  {
      sentiment: {
            positive: '0.6',
            negative: '0.4'
    }
}
let searchQuery = CSPToV3Query(csp);
