### PR TITLE
vtn-standard: Clarify sentiment examples, remove polarization

### DIFF
--- a/packages/veritone-json-schemas/schemas/vtn-standard/sentiment/examples/per-phrase.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/sentiment/examples/per-phrase.json
@@ -5,8 +5,8 @@
       "type": "text",
       "text": "I'm feeling mostly good but a little bad I think, with just a twitch of anger; but mostly I'm confused.",
       "page": 3,
-      "paragraph": 15,
-      "sentence": 104,
+      "paragraph": 2,
+      "sentence": 4,
 
       "sentiment": {
         "positiveValue": 0.56,

--- a/packages/veritone-json-schemas/schemas/vtn-standard/sentiment/examples/polarized.negative.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/sentiment/examples/polarized.negative.json
@@ -2,7 +2,6 @@
   "validationContracts": ["sentiment"],
   "sentiment": {
     "positiveValue": 0,
-    "negativeValue": 1,
-    "negativeConfidence": 0.56
+    "negativeValue": 0.08
   }
 }

--- a/packages/veritone-json-schemas/schemas/vtn-standard/sentiment/examples/polarized.positive.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/sentiment/examples/polarized.positive.json
@@ -1,8 +1,7 @@
 {
   "validationContracts": ["sentiment"],
   "sentiment": {
-    "positiveValue": 1,
-    "positiveConfidence": 0.56,
-    "negativeValue": 0
+    "positiveValue": 0.56,
+    "positiveConfidence": 0.9464286
   }
 }

--- a/packages/veritone-json-schemas/schemas/vtn-standard/sentiment/examples/simple-negative.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/sentiment/examples/simple-negative.json
@@ -1,7 +1,6 @@
 {
   "validationContracts": ["sentiment"],
   "sentiment": {
-    "positiveValue": 0,
-    "negativeValue": 0
+    "negativeValue": 0.17
   }
 }


### PR DESCRIPTION
veritione/aiware-core#492

Update examples to match documentation about sentiment representation in vtn-standard.

Also updated the page/paragraph/sentence values to be more realistic according to the docs