### PR TITLE
Export Help

### DIFF
--- a/packages/veritone-react-common/src/components/MediaPlayer/VideoSource.js
+++ b/packages/veritone-react-common/src/components/MediaPlayer/VideoSource.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { arrayOf, shape, string, func, bool } from 'prop-types';
-import { get, find, includes } from 'lodash';
+import { get, find } from 'lodash';
 import shaka from 'shaka-player';
 
 export default class VideoSource extends React.Component {

--- a/packages/veritone-react-common/src/components/MediaPlayer/VideoSource.js
+++ b/packages/veritone-react-common/src/components/MediaPlayer/VideoSource.js
@@ -85,7 +85,7 @@ export default class VideoSource extends React.Component {
     }
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate(_prevProps, prevState) {
     const { video, disablePreload } = this.props;
     if (
       !disablePreload &&

--- a/packages/veritone-react-common/src/index.js
+++ b/packages/veritone-react-common/src/index.js
@@ -38,6 +38,7 @@ export {
 export SearchPill from './components/SearchPill';
 export HorizontalScroll from './components/HorizontalScroll';
 export GeoPicker from './components/GeoPicker';
+export Help from './components/Help';
 export ExpandableInputField from './components/ExpandableInputField';
 export SearchBar from './components/SearchBar';
 export BoundingPolyOverlay from './components/BoundingPolyOverlay/Overlay';
@@ -69,7 +70,6 @@ export {
   SimpleSearchBar,
   EntitySearchTemplate
 } from './components/SimpleSearchBar/SimpleSearchBar';
-
 export {
   Form,
   FormBuilder,


### PR DESCRIPTION
Help is not currently exported from veritone-react-common SDK.

Fix lint warnings, as well.