### PR TITLE
feat(MNE-3323): add jumpLargeGaps configuration into VideoSource

### DIFF
--- a/packages/veritone-react-common/src/components/MediaPlayer/VideoSource.js
+++ b/packages/veritone-react-common/src/components/MediaPlayer/VideoSource.js
@@ -74,6 +74,11 @@ export default class VideoSource extends React.Component {
       }
       if (!this.player) {
         this.player = new shaka.Player(video);
+        this.player.configure({
+          streaming: {
+            jumpLargeGaps: true,
+          }
+        });
         this.player
           .getNetworkingEngine()
           .registerRequestFilter(function (type, request) {


### PR DESCRIPTION
**Link to ticket:**
https://veritone.atlassian.net/browse/MNE-3323

**Description:**
- Currently, if media has multi periods, the video will be stuck at the end of the first period. The solution is to add the `jumpLargeGaps` configuration which enables the video auto play the next period.

**How to test:**
- At the root folder, run `cd ./packages/veritone-react-common && yarn && yarn build`
- After the build is done, copy the folder `veritone-react-common` to `discovery-app/node_modules`
- Run the `discovery-app` with prod data ([How to use prod data locally](https://veritone.atlassian.net/wiki/spaces/~84864199/pages/3053814008/Cors+Bypass+cors+when+using+Prod+data+locally))
- Login to the app, use Org: Fox Women’s World Cup (46036) - user: [minh.hoang+46036@setacinq.vn](mailto:minh.hoang+46036@setacinq.vn) already has data for testing.
- Search by Recognized Text with the keyword **"camping world"**
- Play some multi periods videos in search results to check whether the video is stuck.

_How to check whether a video has multi periods_
- Open tab Network in DevTool.
- Expand a search result, the cursor should hover on video to load `dash.mpd` file.
- See the response, if has more than one <Period> tag => this is multi periods video.

![how_to_check_multi_periods](https://github.com/veritone/veritone-sdk/assets/83629983/c09a79e5-58cf-4193-a506-e44ca8e230de)


**Test result:**
My testing video had been stuck at 37s, but with new configuration added, the video should play normally at that time.

https://github.com/veritone/veritone-sdk/assets/83629983/8bea940c-9aa3-480b-a822-482e07205e6d


