### PR TITLE
[Illuminate] - veritone-react-components - Warning: Using UNSAFE_componentWillReceiveProps in strict mode is not recommended and may indicate bugs in your code. 

### DIFF
--- a/packages/veritone-redux-common/src/util/saga/react-redux-saga.js
+++ b/packages/veritone-redux-common/src/util/saga/react-redux-saga.js
@@ -43,10 +43,6 @@ export class Saga extends Component {
     this.runningSaga = this.context.sagas.run(this.props.saga, this.props);
   }
 
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    // ??
-  }
-
   render() {
     return !this.props.children ? null : Children.only(this.props.children);
   }


### PR DESCRIPTION
Ticket: [[Illuminate] - veritone-react-components - Warning: Using UNSAFE_componentWillReceiveProps in strict mode is not recommended and may indicate bugs in your code. ](https://veritone.atlassian.net/browse/GLC-4552)