### PR TITLE
Move JSON schemas to get.aiware.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,7 @@ _This is WIP and may change as we find a better process_
 9. Run `yarn publish` in each package directory as needed to push your release to NPM.
 
 ## veritone-json-schema
-The JSON schema is deployed to the documentation page (docs.veritone.com). 
-This may be deployed manually with
-```bash
-aws s3 sync \
-  github.com/veritone/veritone-sdk/packages/veritone-json-schemas/schemas/vtn-standard \
-  s3://veritone-docs-prod/schemas/vtn-standard
-```
-(with appropriate updates for the local directory)
+See packages/veritone-json-schema/README.md
 
 # Creating development/integration bundles (for internal Veritone use)
 Occasionally you may need to integrate unfinished work on an SDK package with another project. In cases where that project must be deployed or shared, we cannot rely on `yarn link`. Rather than cluttering our ecosystem with with prerelease package versions, you can publish a tar archive to an S3 bucket and reference that archive in the package.json of your project (using yarn's ability to download tarball dependencies).

--- a/packages/veritone-json-schemas/README.md
+++ b/packages/veritone-json-schemas/README.md
@@ -4,6 +4,20 @@ This repo contains all the static JSON schemas used by Veritone.
 This does **not** include the [user-defined schemas registered through Veritone Developer](https://docs.veritone.com/#/developer/data/),
 just the ones that are core to our platform.
 
+## Releasing
+
+The JSON schema is deployed to the get.aiware.com
+site (https://get.aiware.com/schemas/index.html). 
+This may be deployed manually with
+```bash
+AWS_PROFILE=default
+aws --profile=$AWS_PROFILE s3 cp schemas/vtn-standard/index.html s3://aiware-prod-public/schemas/index.html
+for schema in $(find schemas/vtn-standard -name '*.json' | grep -v "examples"); do
+  aws --profile=$AWS_PROFILE s3 cp $schema s3://aiware-prod-public/${schema/vtn-standard\//}
+done
+```
+(with appropriate updates for the local directory)
+
 ## Usage
 
 This package exports a map of valid validation contract names to their validating functions and looks like the following:

--- a/packages/veritone-json-schemas/schemas/vtn-standard/aion/aion.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/aion/aion.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://docs.veritone.com/schemas/vtn-standard/aion/aion.json",
+  "$id": "https://get.aiware.com/schemas/aion/aion.json",
   "title": "Engine output for any Veritone cognition engine: AI Object Notation (AION)",
   "description": "Contains unstructured data about the contents of media (video, audio, image, or document). Used to validate the Media Type application/vnd.veritone.aion+json. Informal documentation/example is available at https://docs.veritone.com/#/developer/engines/standards/engine-output/",
   "type": "object",

--- a/packages/veritone-json-schemas/schemas/vtn-standard/aion/examples/documentation-sample.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/aion/examples/documentation-sample.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/master.json",
+  "schemaId": "https://get.aiware.com/schemas/master.json",
   "sourceEngineId": "<GUID>",
   "sourceEngineName": "engine_x",
   "taskPayload": {},

--- a/packages/veritone-json-schemas/schemas/vtn-standard/anomaly/anomaly.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/anomaly/anomaly.json
@@ -1,89 +1,82 @@
 {
-    "$schema": "https://docs.veritone.com/schemas/vtn-standard/master.json",
-    "$id": "https://docs.veritone.com/schemas/vtn-standard/anomaly/anomaly.json",
-    "title": "vtn-standard.anomaly",
-    "description": "Standard engine output for Anomalies at Veritone",
-    "type": "object",
-    "definitions": {
-      "anomalyObject": {
-        "allOf": [
-          {
-            "$ref": "../master.json#/definitions/objectResult"
-          },
-          {
-            "properties": {
-              "type": {
-                "const": "anomaly"
-              }
-            }
-          }
-        ]
-      }
-    },
-    "allOf": [
-      {
-        "$ref": "../master.json#/definitions/PREAMBLE"
-      },
-      {
-        "$ref": "../master.json#/definitions/validated"
-      },
-      {
-        "properties": {
-          "validationContracts": {
-            "type": "array",
-            "contains": {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://get.aiware.com/schemas/anomaly/anomaly.json",
+  "title": "vtn-standard.anomaly",
+  "description": "Standard engine output for Anomalies at Veritone",
+  "type": "object",
+  "definitions": {
+    "anomalyObject": {
+      "allOf": [
+        {
+          "$ref": "../master.json#/definitions/objectResult"
+        },
+        {
+          "properties": {
+            "type": {
               "const": "anomaly"
-            }
-          },
-          "object": {
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/anomalyObject"
-            }
-          },
-          "series": {
-            "type": "array",
-            "items": {
-              "allOf": [
-                {
-                  "$ref": "../master.json#/definitions/seriesItem"
-                },
-                {
-                  "properties": {
-                    "object": {
-                      "allOf": [
-                        {
-                          "$ref": "#/definitions/anomalyObject"
-                        },
-                        {
-                          "$ref": "../master.json#/definitions/noDocumentIndexing"
-                        }
-                      ]
-                    }
-                  },
-                  "required": ["object"]
-                }
-              ]
             }
           }
         }
-      },
-      {
-        "anyOf": [
-          {
-            "required": ["object"]
-          },
-          {
-            "required": ["series"]
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "$ref": "../master.json#/definitions/PREAMBLE"
+    },
+    {
+      "$ref": "../master.json#/definitions/validated"
+    },
+    {
+      "properties": {
+        "validationContracts": {
+          "type": "array",
+          "contains": {
+            "const": "anomaly"
           }
-        ]
+        },
+        "object": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/anomalyObject"
+          }
+        },
+        "series": {
+          "type": "array",
+          "items": {
+            "allOf": [
+              {
+                "$ref": "../master.json#/definitions/seriesItem"
+              },
+              {
+                "properties": {
+                  "object": {
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/anomalyObject"
+                      },
+                      {
+                        "$ref": "../master.json#/definitions/noDocumentIndexing"
+                      }
+                    ]
+                  }
+                },
+                "required": ["object"]
+              }
+            ]
+          }
+        }
       }
-    ]
-  }
-  
-  
-  
-  
-  
-  
-  
+    },
+    {
+      "anyOf": [
+        {
+          "required": ["object"]
+        },
+        {
+          "required": ["series"]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/veritone-json-schemas/schemas/vtn-standard/concept/concept.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/concept/concept.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://docs.veritone.com/schemas/vtn-standard/master.json",
-  "$id": "https://docs.veritone.com/schemas/vtn-standard/concept/concept.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://get.aiware.com/schemas/concept/concept.json",
   "title": "vtn-standard.concept",
   "description": "Standard engine output for Content Classification at Veritone",
   "type": "object",

--- a/packages/veritone-json-schemas/schemas/vtn-standard/entity/entity.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/entity/entity.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://docs.veritone.com/schemas/vtn-standard/master.json",
-  "$id": "https://docs.veritone.com/schemas/vtn-standard/entity/entity.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://get.aiware.com/schemas/entity/entity.json",
   "title": "vtn-standard.entity",
   "description": "Standard engine output for Entity Extraction at Veritone",
   "type": "object",

--- a/packages/veritone-json-schemas/schemas/vtn-standard/index.html
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/index.html
@@ -1,0 +1,27 @@
+<html>
+  <head>
+    <title>Veritone Standard JSON Schemas</title>
+  </head>
+  <body>
+    <h1>Veritone Standard JSON Schemas</h1>
+    <p>
+      This directory contains the standard JSON schemas used by Veritone.
+    </p>
+    <h2>Schema List</h2>
+    <ul>
+      <li><a href="./master.json">Master Definitions</a></li>
+      <li><a href="./aion/aion.json">AI Object Notation (AION)</a></li>
+      <li><a href="./anomaly/anomaly.json">Anomaly</a></li>
+      <li><a href="./concept/concept.json">Concept</a></li>
+      <li><a href="./entity/entity.json">Entity</a></li>
+      <li><a href="./keyword/keyword.json">Keyword</a></li>
+      <li><a href="./language/language.json">Language</a></li>
+      <li><a href="./media-translated/media-translated.json">Translated Media</a></li>
+      <li><a href="./object/object.json">Object</a></li>
+      <li><a href="./sentiment/sentiment.json">Sentiment</a></li>
+      <li><a href="./summary/summary.json">Summary</a></li>
+      <li><a href="./text/text.json">Text</a></li>
+      <li><a href="./transcript/transcript.json">Transcript</a></li>
+          </ul>
+  </body>
+</html>

--- a/packages/veritone-json-schemas/schemas/vtn-standard/keyword/keyword.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/keyword/keyword.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://docs.veritone.com/schemas/vtn-standard/master.json",
-  "$id": "https://docs.veritone.com/schemas/vtn-standard/keyword/keyword.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://get.aiware.com/schemas/keyword/keyword.json",
   "title": "vtn-standard.keyword",
   "description": "Standard engine output for Keyword Extraction at Veritone",
   "type": "object",

--- a/packages/veritone-json-schemas/schemas/vtn-standard/language/language.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/language/language.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://docs.veritone.com/schemas/vtn-standard/master.json",
-  "$id": "https://docs.veritone.com/schemas/vtn-standard/language/language.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://get.aiware.com/schemas/language/language.json",
   "title": "vtn-standard.language",
   "description": "Standard engine output for Language Identification at Veritone",
   "type": "object",

--- a/packages/veritone-json-schemas/schemas/vtn-standard/master.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/master.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://docs.veritone.com/schemas/vtn-standard/master.json",
+  "$id": "https://get.aiware.com/schemas/master.json",
   "title": "vtn-standard",
   "description": "Standard engine output at Veritone",
   "type": "object",
@@ -100,9 +100,7 @@
     "schemaId": {
       "description": "vtn-standard.master.schema.json or subschema.schema.json (provided by Veritone)",
       "type": "string",
-      "examples": [
-        "https://docs.veritone.com/schemas/vtn-standard/aion/aion.json"
-      ]
+      "examples": ["https://get.aiware.com/schemas/aion/aion.json"]
     },
     "guid": {
       "description": "A globally unique ID. Typically a UUID in the 8-4-4-4-12 character format, but it doesn't have to be a UUID",

--- a/packages/veritone-json-schemas/schemas/vtn-standard/media-translated/media-translated.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/media-translated/media-translated.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://docs.veritone.com/schemas/vtn-standard/master.json",
-  "$id": "https://docs.veritone.com/schemas/vtn-standard/media-translated/media-translated.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://get.aiware.com/schemas/media-translated/media-translated.json",
   "title": "vtn-standard.media-translated",
   "description": "Standard engine output for translated text files at Veritone",
   "type": "object",

--- a/packages/veritone-json-schemas/schemas/vtn-standard/object/examples/from-docs.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/object/examples/from-docs.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/master.json",
+  "schemaId": "https://get.aiware.com/schemas/master.json",
   "validationContracts": ["object"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/object/examples/full-capability.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/object/examples/full-capability.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/object.json",
+  "schemaId": "https://get.aiware.com/schemas/object.json",
   "validationContracts": ["object"],
   "object": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/object/examples/series.with.internal.reference.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/object/examples/series.with.internal.reference.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/object.json",
+  "schemaId": "https://get.aiware.com/schemas/object.json",
   "validationContracts": ["object"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/object/examples/series.without.internal.reference.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/object/examples/series.without.internal.reference.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/object.json",
+  "schemaId": "https://get.aiware.com/schemas/object.json",
   "validationContracts": ["object"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/object/examples/summary.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/object/examples/summary.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/object.json",
+  "schemaId": "https://get.aiware.com/schemas/object.json",
   "validationContracts": ["object"],
   "object": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/object/examples/summary.with.no.entries.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/object/examples/summary.with.no.entries.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/object.json",
+  "schemaId": "https://get.aiware.com/schemas/object.json",
   "validationContracts": ["object"],
   "object": []
 }

--- a/packages/veritone-json-schemas/schemas/vtn-standard/object/examples/without-label.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/object/examples/without-label.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/object.json",
+  "schemaId": "https://get.aiware.com/schemas/object.json",
   "validationContracts": ["object"],
   "object": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/full-capability.empty.object.category.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/full-capability.empty.object.category.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/object.json",
+  "schemaId": "https://get.aiware.com/schemas/object.json",
   "validationContracts": ["object"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/full-capability.invalid.confidence.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/full-capability.invalid.confidence.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/object.json",
+  "schemaId": "https://get.aiware.com/schemas/object.json",
   "validationContracts": ["object"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/full-capability.invalid.type.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/full-capability.invalid.type.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/object.json",
+  "schemaId": "https://get.aiware.com/schemas/object.json",
   "validationContracts": ["object"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/full-capability.null.object.category.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/full-capability.null.object.category.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/object.json",
+  "schemaId": "https://get.aiware.com/schemas/object.json",
   "validationContracts": ["object"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/full-capability.object.category.invalid.class.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/full-capability.object.category.invalid.class.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/object.json",
+  "schemaId": "https://get.aiware.com/schemas/object.json",
   "validationContracts": ["object"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/full-capability.object.category.no.class.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/full-capability.object.category.no.class.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/object.json",
+  "schemaId": "https://get.aiware.com/schemas/object.json",
   "validationContracts": ["object"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/full-capability.wrong.type.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/full-capability.wrong.type.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/object.json",
+  "schemaId": "https://get.aiware.com/schemas/object.json",
   "validationContracts": ["object"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/missing-validation-contract.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/missing-validation-contract.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/object.json",
+  "schemaId": "https://get.aiware.com/schemas/object.json",
   "object": [
     {
       "type": "object",

--- a/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/series.missing.start.time.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/series.missing.start.time.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/object.json",
+  "schemaId": "https://get.aiware.com/schemas/object.json",
   "validationContracts": ["object"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/series.missing.stop.time.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/series.missing.stop.time.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/object.json",
+  "schemaId": "https://get.aiware.com/schemas/object.json",
   "validationContracts": ["object"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/series.no.data.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/series.no.data.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/master.json",
+  "schemaId": "https://get.aiware.com/schemas/master.json",
   "validationContracts": ["object"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/series.with-document-indexing.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/series.with-document-indexing.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/object.json",
+  "schemaId": "https://get.aiware.com/schemas/object.json",
   "validationContracts": ["object"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/series.with-extra-properties.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/series.with-extra-properties.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/object.json",
+  "schemaId": "https://get.aiware.com/schemas/object.json",
   "validationContracts": ["object"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/series.with.invalid.bounding.poly.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/series.with.invalid.bounding.poly.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/object.json",
+  "schemaId": "https://get.aiware.com/schemas/object.json",
   "validationContracts": ["object"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/series.with.invalid.label.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/series.with.invalid.label.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/object.json",
+  "schemaId": "https://get.aiware.com/schemas/object.json",
   "validationContracts": ["object"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/series.with.negative.startTime.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/series.with.negative.startTime.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/object.json",
+  "schemaId": "https://get.aiware.com/schemas/object.json",
   "validationContracts": ["object"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/summary.with.empty.result.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/summary.with.empty.result.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/object.json",
+  "schemaId": "https://get.aiware.com/schemas/object.json",
   "validationContracts": ["object"],
   "object": [{}]
 }

--- a/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/summary.with.invalid.bounding.poly.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/summary.with.invalid.bounding.poly.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/object.json",
+  "schemaId": "https://get.aiware.com/schemas/object.json",
   "validationContracts": ["object"],
   "object": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/summary.with.time.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/summary.with.time.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/object.json",
+  "schemaId": "https://get.aiware.com/schemas/object.json",
   "validationContracts": ["object"],
   "object": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/wrong-object-type.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/object/invalid-examples/wrong-object-type.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/object.json",
+  "schemaId": "https://get.aiware.com/schemas/object.json",
   "validationContracts": ["object"],
   "object": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/object/object.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/object/object.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://docs.veritone.com/schemas/vtn-standard/master.json",
-  "$id": "https://docs.veritone.com/schemas/vtn-standard/object/object.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://get.aiware.com/schemas/object/object.json",
   "title": "vtn-standard.object",
   "description": "Standard engine output for Object at Veritone",
   "definitions": {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/sentiment/sentiment.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/sentiment/sentiment.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://docs.veritone.com/schemas/vtn-standard/master.json",
-  "$id": "https://docs.veritone.com/schemas/vtn-standard/sentiment/sentiment.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://get.aiware.com/schemas/sentiment/sentiment.json",
   "title": "vtn-standard.sentiment",
   "description": "Standard engine output for Sentiment at Veritone",
   "type": "object",

--- a/packages/veritone-json-schemas/schemas/vtn-standard/summary/summary.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/summary/summary.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://docs.veritone.com/schemas/vtn-standard/master.json",
-  "$id": "https://docs.veritone.com/schemas/vtn-standard/summary/summary.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://get.aiware.com/schemas/summary/summary.json",
   "title": "vtn-standard.summary",
   "description": "Standard engine output for Text Summary at Veritone",
   "type": "object",

--- a/packages/veritone-json-schemas/schemas/vtn-standard/text/examples/extracted-text.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/text/examples/extracted-text.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/master.json",
+  "schemaId": "https://get.aiware.com/schemas/master.json",
   "validationContracts": ["text"],
   "object": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/text/examples/extracted-text.with-language.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/text/examples/extracted-text.with-language.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/master.json",
+  "schemaId": "https://get.aiware.com/schemas/master.json",
   "validationContracts": ["text"],
   "language": "fr",
   "object": [

--- a/packages/veritone-json-schemas/schemas/vtn-standard/text/examples/recognized-text-no-series.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/text/examples/recognized-text-no-series.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/master.json",
+  "schemaId": "https://get.aiware.com/schemas/master.json",
   "validationContracts": ["text"],
   "language": "en-US",
   "object": [

--- a/packages/veritone-json-schemas/schemas/vtn-standard/text/examples/recognized-text.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/text/examples/recognized-text.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/master.json",
+  "schemaId": "https://get.aiware.com/schemas/master.json",
   "validationContracts": ["text"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/text/examples/recognized-text.with-language.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/text/examples/recognized-text.with-language.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/master.json",
+  "schemaId": "https://get.aiware.com/schemas/master.json",
   "validationContracts": ["text"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/text/invalid-examples/missing-validation-contract.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/text/invalid-examples/missing-validation-contract.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/master.json",
+  "schemaId": "https://get.aiware.com/schemas/master.json",
   "object": [
     {
       "type": "text",

--- a/packages/veritone-json-schemas/schemas/vtn-standard/text/invalid-examples/recognized-text.with-document-indexing-in-series.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/text/invalid-examples/recognized-text.with-document-indexing-in-series.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/master.json",
+  "schemaId": "https://get.aiware.com/schemas/master.json",
   "validationContracts": ["text"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/text/text.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/text/text.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://docs.veritone.com/schemas/vtn-standard/master.json",
-  "$id": "https://docs.veritone.com/schemas/vtn-standard/text/text.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://get.aiware.com/schemas/text/text.json",
   "title": "vtn-standard.text",
   "description": "Standard engine output for Text at Veritone",
   "type": "object",

--- a/packages/veritone-json-schemas/schemas/vtn-standard/transcript/examples/basic.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/transcript/examples/basic.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/transcript.json",
+  "schemaId": "https://get.aiware.com/schemas/transcript.json",
   "validationContracts": ["transcript"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/transcript/examples/confidence.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/transcript/examples/confidence.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/transcript.json",
+  "schemaId": "https://get.aiware.com/schemas/transcript.json",
   "validationContracts": ["transcript"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/transcript/examples/lattice.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/transcript/examples/lattice.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/transcript.json",
+  "schemaId": "https://get.aiware.com/schemas/transcript.json",
   "validationContracts": ["transcript"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/transcript/examples/translated.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/transcript/examples/translated.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/transcript.json",
+  "schemaId": "https://get.aiware.com/schemas/transcript.json",
   "validationContracts": ["transcript"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/basic.empty.words.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/basic.empty.words.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/transcript.json",
+  "schemaId": "https://get.aiware.com/schemas/transcript.json",
   "validationContracts": ["transcript"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/basic.extra.field.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/basic.extra.field.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/transcript.json",
+  "schemaId": "https://get.aiware.com/schemas/transcript.json",
   "validationContracts": ["transcript"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/basic.integer.sourceEngineId.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/basic.integer.sourceEngineId.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/transcript.json",
+  "schemaId": "https://get.aiware.com/schemas/transcript.json",
   "validationContracts": ["transcript"],
   "sourceEngineId": 3,
   "series": [

--- a/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/basic.invalid.language.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/basic.invalid.language.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/transcript.json",
+  "schemaId": "https://get.aiware.com/schemas/transcript.json",
   "validationContracts": ["transcript"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/basic.invalid.series.language.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/basic.invalid.series.language.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/transcript.json",
+  "schemaId": "https://get.aiware.com/schemas/transcript.json",
   "validationContracts": ["transcript"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/basic.invalid.validationContract.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/basic.invalid.validationContract.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/transcript.json",
+  "schemaId": "https://get.aiware.com/schemas/transcript.json",
   "validationContracts": ["transcripts"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/basic.invalid.word.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/basic.invalid.word.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/transcript.json",
+  "schemaId": "https://get.aiware.com/schemas/transcript.json",
   "validationContracts": ["transcript"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/basic.missing.start.time.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/basic.missing.start.time.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/transcript.json",
+  "schemaId": "https://get.aiware.com/schemas/transcript.json",
   "validationContracts": ["transcript"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/basic.missing.stop.time.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/basic.missing.stop.time.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/transcript.json",
+  "schemaId": "https://get.aiware.com/schemas/transcript.json",
   "validationContracts": ["transcript"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/basic.negative.confidence.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/basic.negative.confidence.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/transcript.json",
+  "schemaId": "https://get.aiware.com/schemas/transcript.json",
   "validationContracts": ["transcript"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/basic.negative.startTime.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/basic.negative.startTime.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/transcript.json",
+  "schemaId": "https://get.aiware.com/schemas/transcript.json",
   "validationContracts": ["transcript"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/basic.no.words.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/basic.no.words.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/transcript.json",
+  "schemaId": "https://get.aiware.com/schemas/transcript.json",
   "validationContracts": ["transcript"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/basic.string.confidence.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/basic.string.confidence.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/transcript.json",
+  "schemaId": "https://get.aiware.com/schemas/transcript.json",
   "validationContracts": ["transcript"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/lattice.missing.confidence.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/lattice.missing.confidence.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/transcript.json",
+  "schemaId": "https://get.aiware.com/schemas/transcript.json",
   "validationContracts": ["transcript"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/lattice.missing.utterance.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/lattice.missing.utterance.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/transcript.json",
+  "schemaId": "https://get.aiware.com/schemas/transcript.json",
   "validationContracts": ["transcript"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/lattice.no.best.path.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/lattice.no.best.path.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/transcript.json",
+  "schemaId": "https://get.aiware.com/schemas/transcript.json",
   "validationContracts": ["transcript"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/lattice.utterance.below.one.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/lattice.utterance.below.one.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/transcript.json",
+  "schemaId": "https://get.aiware.com/schemas/transcript.json",
   "validationContracts": ["transcript"],
   "series": [
     {

--- a/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/missing-validation-contract.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/transcript/invalid-examples/missing-validation-contract.json
@@ -1,5 +1,5 @@
 {
-  "schemaId": "https://docs.veritone.com/schemas/vtn-standard/transcript.json",
+  "schemaId": "https://get.aiware.com/schemas/transcript.json",
   "series": [
     {
       "startTimeMs": 0,

--- a/packages/veritone-json-schemas/schemas/vtn-standard/transcript/transcript.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/transcript/transcript.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://docs.veritone.com/schemas/vtn-standard/master.json",
-  "$id": "https://docs.veritone.com/schemas/vtn-standard/transcript/transcript.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://get.aiware.com/schemas/transcript/transcript.json",
   "title": "vtn-standard.transcript",
   "description": "Standard engine output for Transcription at Veritone",
   "type": "object",

--- a/packages/veritone-json-schemas/src/index.test.js
+++ b/packages/veritone-json-schemas/src/index.test.js
@@ -70,7 +70,7 @@ test('it should export a transcript validator', () => {
 
 test('it should invalidate an object with extra properties in the summary object array', () => {
   const objectSummaryWithTimeFields = {
-    schemaId: 'https://docs.veritone.com/schemas/vtn-standard/object.json',
+    schemaId: 'https://get.aiware.com/schemas/object.json',
     validationContracts: ['object'],
     object: [
       {
@@ -108,7 +108,7 @@ test('it should invalidate an object with extra properties in the summary object
 
 test('it should invalidate a transcript with extra properties', () => {
   const transcriptWithExtraField = {
-    schemaId: 'https://docs.veritone.com/schemas/vtn-standard/transcript.json',
+    schemaId: 'https://get.aiware.com/schemas/transcript.json',
     validationContracts: ['transcript'],
     series: [
       {


### PR DESCRIPTION
JSON schemas used to be published to the docs.veritone.com site, but that site has been borged into support.veritone.com and can no longer host raw documents. (All pages on that site are "articles" that are dynamically generated HTML whose contents are read from a database, so it is no longer possible to host a raw JSON or text file. [Here is an example](https://support.veritone.com/s/article/000005031?language=en_US) of our "new" schema files since it has been moved to support)

The JSON schema files have been converted to be hosted at https://get.aiware.com/schemas (see https://get.aiware.com/schemas/index.html) and the release instructions updated accordingly.