### PR TITLE
VE-3102: Update internalTaskId to type string

### DIFF
--- a/packages/veritone-json-schemas/schemas/vtn-standard/master.json
+++ b/packages/veritone-json-schemas/schemas/vtn-standard/master.json
@@ -44,7 +44,7 @@
         },
         "internalTaskId": {
           "description": "ID of the internal task. A part of the GLC prototype",
-          "$ref": "#/definitions/guid"
+          "type": "string"
         }
       }
     },


### PR DESCRIPTION
# Description
Update `internalTaskId` to type string for safety, because although aiware taskIds are guid but maybe edge taskIds can change to not guid in the future.

Rely on the PR comment: https://github.com/veritone/aiware-core/pull/2383#discussion_r1670869478

## Related Issue

https://veritone.atlassian.net/browse/VE-3102

## How Has This Been Tested
1. Run `npm i && npm run test` in /packages/veritone-json-schemas folder.
2. Ensure that all tests are passed. 